### PR TITLE
feat: Inform user if redirected when trying to RSVP

### DIFF
--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -106,6 +106,7 @@ class RsvpsController < ApplicationController
 
   def require_accepted_questionnaire
     return if @questionnaire.can_rsvp? || @questionnaire.checked_in?
+    
     flash[:alert] = "You had not been accepted"
     redirect_to new_questionnaires_path
   end

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -107,7 +107,7 @@ class RsvpsController < ApplicationController
   def require_accepted_questionnaire
     return if @questionnaire.can_rsvp? || @questionnaire.checked_in?
 
-    flash[:alert] = "You had not been accepted"
+    flash[:alert] = "Sorry, you have not been accepted at this time. Please wait for an acceptance email before attempting to RSVP."
     redirect_to new_questionnaires_path
   end
 end

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -106,7 +106,7 @@ class RsvpsController < ApplicationController
 
   def require_accepted_questionnaire
     return if @questionnaire.can_rsvp? || @questionnaire.checked_in?
-    
+
     flash[:alert] = "You had not been accepted"
     redirect_to new_questionnaires_path
   end

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -106,7 +106,7 @@ class RsvpsController < ApplicationController
 
   def require_accepted_questionnaire
     return if @questionnaire.can_rsvp? || @questionnaire.checked_in?
-
+    flash[:alert] = "You had not been accepted"
     redirect_to new_questionnaires_path
   end
 end


### PR DESCRIPTION
A very simple alert is set before the user is redirect to new questionnaire page if they have not been accepted.

Fixes #32 