### PR TITLE
ci: Fix MySQL support for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 
 # "test" step configuration
 language: ruby
+services:
+  - mysql
 rvm:
   - 2.6
   - 2.5


### PR DESCRIPTION
Travis CI doesn't auto-start databases anymore; we have to explicitly specify MySQL as a dependent service

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment