### PR TITLE
fix(questionnaire):  visual bug in school autocomplete dropdown

### DIFF
--- a/app/assets/stylesheets/forms/_forms.sass
+++ b/app/assets/stylesheets/forms/_forms.sass
@@ -261,9 +261,10 @@ input[type=submit]
     color: var(--input--text--focus)
   list-style: none
   padding: 0
-  .ui-menu-item a
+  .ui-menu-item div
     padding: 2px 5px
     display: block
+    cursor: pointer
     &:hover, &.ui-state-focus
       @include css4
         background: var(--primary)


### PR DESCRIPTION
the css was set for an "a" tag when the list was made up of divs so I
switched the css to work for the "div" tag in the autocomplete