### PR TITLE
fix(Dashboard): Fixes missing location data in map

### DIFF
--- a/app/views/manage/dashboard/map_data.tsv.erb
+++ b/app/views/manage/dashboard/map_data.tsv.erb
@@ -23,8 +23,8 @@ redo_limit = 10
     addressMatches = result["addressMatches"]
     next if addressMatches.blank?
 
-    lat = result["addressMatches"][0]["coordinates"]["x"]
-    lng = result["addressMatches"][0]["coordinates"]["y"]
+    lng = result["addressMatches"][0]["coordinates"]["x"]
+    lat = result["addressMatches"][0]["coordinates"]["y"]
     next if lat.blank? || lng.blank?
 
     resp = HTTParty.get("https://geo.fcc.gov/api/census/area?lat=#{lat}&lon=#{lng}&format=json")


### PR DESCRIPTION
Simple swap of latitude and longitude. Must've made an error when we switched Geocoding APIs.

fixes #323 