### PR TITLE
refactor: Changes "Applications" to "Questionnaires" in map

### DIFF
--- a/app/assets/javascripts/manage/map.js
+++ b/app/assets/javascripts/manage/map.js
@@ -61,7 +61,7 @@ $.fn.initMap = function() {
       })
       .append('title')
       .text(function(d) {
-        return d.properties.name + '\nApplications: ' + formatNumber(appsById.get(d.id) || 0);
+        return d.properties.name + '\nQuestionnaires: ' + formatNumber(appsById.get(d.id) || 0);
       });
   }
 


### PR DESCRIPTION
When hovering over a country in the Dashboard Map it'll now display "Questionnaires: x" rather than "Applications: x".

closes #325 