### PR TITLE
fix: Hackathon names now consistently on newline, wrapping is centered

### DIFF
--- a/app/assets/stylesheets/forms/_forms.sass
+++ b/app/assets/stylesheets/forms/_forms.sass
@@ -61,6 +61,11 @@ hr
   .btn
     margin-bottom: 30px
 
+.text-overflow-center
+  text-align: center
+  display: flex
+  justify-content: center
+
 .simple_form
   @include css4
     color: var(--grey)

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -2,7 +2,7 @@
 .form-container.password
   .section-title.center
     Change Your
-    %div.emphasized Password
+    .emphasized Password
   = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
     = f.error_notification
     = f.input :reset_password_token, as: :hidden

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -2,7 +2,7 @@
 .form-container.password
   .section-title.center
     Change Your
-    %span.emphasized Password
+    %div.emphasized Password
   = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
     = f.error_notification
     = f.input :reset_password_token, as: :hidden

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -2,6 +2,6 @@
 .form-container.password
   %h1.section-title.center
     Reset Your
-    %div.emphasized Password
+    .emphasized Password
 
   = render 'form'

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -2,6 +2,6 @@
 .form-container.password
   %h1.section-title.center
     Reset Your
-    %span.emphasized Password
+    %div.emphasized Password
 
   = render 'form'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,7 +2,7 @@
 .form-container.signup
   %h1.section-title.center
     Register for
-    %span.emphasized= HackathonConfig['name']
+    %div.emphasized.text-overflow-center= HackathonConfig['name']
 
   - if !HackathonConfig['accepting_questionnaires'] || HackathonConfig['disclaimer_message'].present?
     #disclaimer

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,7 +2,7 @@
 .form-container.signup
   %h1.section-title.center
     Register for
-    %div.emphasized.text-overflow-center= HackathonConfig['name']
+    .emphasized.text-overflow-center= HackathonConfig['name']
 
   - if !HackathonConfig['accepting_questionnaires'] || HackathonConfig['disclaimer_message'].present?
     #disclaimer

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,5 +2,5 @@
 .form-container.login
   %h1.section-title.center
     Sign in to
-    %span.emphasized= HackathonConfig['name']
+    %div.emphasized.text-overflow-center= HackathonConfig['name']
   = render 'form'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,5 +2,5 @@
 .form-container.login
   %h1.section-title.center
     Sign in to
-    %div.emphasized.text-overflow-center= HackathonConfig['name']
+    .emphasized.text-overflow-center= HackathonConfig['name']
   = render 'form'

--- a/app/views/questionnaires/new.html.haml
+++ b/app/views/questionnaires/new.html.haml
@@ -3,7 +3,7 @@
   .form-container
     %h1.section-title
       Apply for
-      %span.emphasized= HackathonConfig['name']
+      %div.emphasized.text-overflow-center= HackathonConfig['name']
   = render 'form'
 - else
   .form-container

--- a/app/views/questionnaires/new.html.haml
+++ b/app/views/questionnaires/new.html.haml
@@ -3,7 +3,7 @@
   .form-container
     %h1.section-title
       Apply for
-      %div.emphasized.text-overflow-center= HackathonConfig['name']
+      .emphasized.text-overflow-center= HackathonConfig['name']
   = render 'form'
 - else
   .form-container


### PR DESCRIPTION
Fixes #223 

Short hackathon names are on newline:
<img src="https://user-images.githubusercontent.com/2782749/93692512-47988a00-fac2-11ea-965e-ec5383d7173f.png" width="300px" /> 
Long hackathon names wrap in a centered way while maintaining existing container width:
<img src="https://user-images.githubusercontent.com/2782749/93692543-92b29d00-fac2-11ea-984c-43bebc86428a.png" width="300px" />
Similar pages match this newline style even if they do not use hackathon name (only password reset and devise edit form)
<img src="https://user-images.githubusercontent.com/2782749/93692568-ca214980-fac2-11ea-9c40-c17e7733f790.png" width="300px" />
