### PR TITLE
fix: Text centering on application page 

### DIFF
--- a/app/views/questionnaires/new.html.haml
+++ b/app/views/questionnaires/new.html.haml
@@ -1,9 +1,9 @@
 - title "Application"
 - if HackathonConfig['accepting_questionnaires']
   .form-container
-    %h1.section-title.center
+    %h1.section-title
       Apply for
-      .emphasized.text-overflow-center= HackathonConfig['name']
+      %span.emphasized= HackathonConfig['name']
   = render 'form'
 - else
   .form-container

--- a/app/views/questionnaires/new.html.haml
+++ b/app/views/questionnaires/new.html.haml
@@ -1,7 +1,7 @@
 - title "Application"
 - if HackathonConfig['accepting_questionnaires']
   .form-container
-    %h1.section-title
+    %h1.section-title.center
       Apply for
       .emphasized.text-overflow-center= HackathonConfig['name']
   = render 'form'


### PR DESCRIPTION
Long container forms have left aligned text while previous PR #358 maintains that small forms have linebreak
