### PR TITLE
Create /user.json get route + test

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,15 @@
+class UsersController < ApplicationController
+
+  before_action :logged_in
+  respond_to :json
+
+  def logged_in
+    authenticate_user!
+  end
+
+  def show
+    respond_to do |format|
+      format.json { render json: current_user }
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-
   before_action :logged_in
   respond_to :json
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     mount Blazer::Engine, at: "blazer"
   end
 
+  # devise doesnt parse GET /user
+  resource :user, only: :show, constraints: lambda { |req| req.format == :json }
+
   resource :questionnaires, path: "apply" do
     get :schools, on: :collection
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   end
 
   # devise doesnt parse GET /user
-  resource :user, only: :show, constraints: lambda { |req| req.format == :json }
+  resource :user, only: :show, constraints: ->(req) { req.format == :json }
 
   resource :questionnaires, path: "apply" do
     get :schools, on: :collection

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+  include ActiveJob::TestHelper
+  setup do
+    @user = create(:user)
+  end
+
+  should "allow access to user#get" do
+    sign_in @user
+    get :show, params: { format: :json }
+    assert_response :success
+  end
+
+  should "don't allow user#show if not signed in" do
+    get :show, params: { format: :json }
+    assert_response(:unauthorized)
+  end
+end


### PR DESCRIPTION
Fixes #222  

New route `/user.json` that, when a user is signed in, returns user data:
```json
{
  "id": 4582,
  "created_at": "2019-12-05T21:26:22.000Z",
  "updated_at": "2020-09-20T07:55:36.000Z",
  "email": "pkos99@gmail.com",
  "provider": null,
  "uid": null,
  "reminder_sent_at": "2019-12-05T21:26:22.000Z",
  "role": "admin_limited_access",
  "is_active": true,
  "receive_weekly_report": false,
  "first_name": "Peter",
  "last_name": "Kos"
}
```

Notes:
- Restricted to **json format only** as no frontend exists for this feature
- I had to bypass devise's registration controller because it wouldn't allow me to create a `show` method in there, nor would the devise route handle an incoming `GET`

