### PR TITLE
Link back to user account page from manage added

### DIFF
--- a/app/views/layouts/manage/application.html.haml
+++ b/app/views/layouts/manage/application.html.haml
@@ -12,14 +12,16 @@
     = csrf_meta_tags
 
   %body
-    %nav.navbar.navbar-dark.fixed-top.bg-dark.flex-nowrap.p-0.shadow
+    %nav.navbar.navbar-expand.navbar-dark.fixed-top.bg-dark.flex-nowrap.p-0.shadow
       %a.navbar-brand.col-xs-6.col-sm-3.col-md-2.mr-0{href: manage_root_path} #{HackathonConfig['name']} Manager
       / %input.form-control.form-control-dark.w-100{"aria-label" => "Search", placeholder: "Search", type: "text"}/
-      %span.navbar-brand.navbar-mobile-toggle.mr-0.pl-3.pr-3{onclick: 'toggleMobileNav()'}
-        .fa.fa-bars.fa-fw.icon-space-r-half
-      %ul.navbar-nav.px-3
+      %ul.navbar-nav.ml-auto.px-3
+        %li.nav-item.text-nowrap
+          = link_to "Account", root_path, class: "nav-link"
         %li.nav-item.text-nowrap
           = link_to "Sign out", destroy_user_session_path, method: :delete, class: "nav-link"
+      %span.navbar-brand.navbar-mobile-toggle.mr-0.pl-3.pr-3{onclick: 'toggleMobileNav()'}
+        .fa.fa-bars.fa-fw.icon-space-r-half
 
     .container-fluid
       .row


### PR DESCRIPTION
Fixes #362 

Added an `Account` button that redirects an organizer back to their account page.
![image](https://user-images.githubusercontent.com/2782749/94646366-17b86600-02bc-11eb-9c2a-355ffa1f5bba.png)

Also flipped the order of "sign out" and the hamburger menu on mobile (before was hamburger, then sign out):

<img src="https://user-images.githubusercontent.com/2782749/94646593-87c6ec00-02bc-11eb-80cd-336a6c531d82.jpg" width="350px" />


Another bug I just found: while this _works_ on mobile, the sidebar itself is utterly broken! It can't scroll. Also, having a destructive action (sign out) next to the action item (menu button) is... strange. Both of these are addressed in #380 