### PR TITLE
fix: Allows optional assets to be unset

### DIFF
--- a/app/controllers/manage/configs_controller.rb
+++ b/app/controllers/manage/configs_controller.rb
@@ -17,7 +17,7 @@ class Manage::ConfigsController < Manage::ApplicationController
     value = params[:hackathon_config][key]
     value = true if value == "true"
     value = false if value == "false"
-    if @config.var.end_with?("_asset") && !value.start_with?('http://', 'https://')
+    if @config.var.start_with?("agreement_") && !value.start_with?('http://', 'https://')
       flash[:alert] = "Config \"#{key}\" must start with http:// or https://"
       render :edit
     elsif @config.value != value

--- a/test/controllers/manage/configs_controller_test.rb
+++ b/test/controllers/manage/configs_controller_test.rb
@@ -152,13 +152,6 @@ class Manage::ConfigsControllerTest < ActionController::TestCase
       assert_redirected_to manage_configs_path
     end
 
-    should "not update logo_asset with an asset that is not URL based" do
-      HackathonConfig["logo_asset"] = ""
-      patch :update, params: { id: "logo_asset", hackathon_config: { logo_asset: "test" } }
-      assert_equal "", HackathonConfig["logo_asset"]
-      assert_template :edit
-    end
-
     should "update config CSS variables when custom_css is blank" do
       HackathonConfig["custom_css"] = ""
       patch :update, params: { id: "custom_css", hackathon_config: { custom_css: ":root {\n  --foo: #fff;\n}" } }


### PR DESCRIPTION
Only enforces the agreement asset to be set. All other assets in config are allowed to be optional.

fixes #405 