### PR TITLE
feat(settings): Simplifies Config

### DIFF
--- a/app/controllers/manage/configs_controller.rb
+++ b/app/controllers/manage/configs_controller.rb
@@ -6,6 +6,11 @@ class Manage::ConfigsController < Manage::ApplicationController
 
   def index
     @config = HackathonConfig.get_all
+    @basics = ['name', 'event_start_date', 'digital_hackathon'].freeze
+    @questionnaire_settings = ['accepting_questionnaires', 'last_day_to_apply', 'auto_late_waitlist', 'disabled_fields'].freeze
+    @styling = ['default_page_title', 'homepage_url', 'logo_asset', 'email_banner_asset', 'favicon_asset', 'custom_css'].freeze
+    @communications = ['email_from', 'disclaimer_message', 'thanks_for_applying_message', 'thanks_for_rsvp_message', 'questionnaires_closed_message', 'bus_captain_notes']
+    @legal = ['agreement_pdf_asset'].freeze
     respond_with(HackathonConfig.get_all)
   end
 

--- a/app/views/manage/configs/index.html.haml
+++ b/app/views/manage/configs/index.html.haml
@@ -4,7 +4,7 @@
   .col-lg-6.mb-3
     .card.mb-3
       .card-body
-        %h4.card-title.font-weight-bold 
+        %h4.card-title.font-weight-bold
           The Basics
         %h6.card-subtitle.mb-2.text-muted
           Core information about your hackathon.

--- a/app/views/manage/configs/index.html.haml
+++ b/app/views/manage/configs/index.html.haml
@@ -39,7 +39,7 @@
           Applying to
           = HackathonConfig['name']
         %h6.card-subtitle.mb-2.text-muted
-          Configuring Questionnaires for your hackathon.
+          Configuring questionnaires for your hackathon.
         - @questionnaire_settings.each_entry do |key|
           - value = HackathonConfig[key]
           %hr

--- a/app/views/manage/configs/index.html.haml
+++ b/app/views/manage/configs/index.html.haml
@@ -35,7 +35,7 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title 
+        %h4.card-title
           Applying to
           = HackathonConfig['name']
         %h6.card-subtitle.mb-2.text-muted
@@ -76,7 +76,7 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title 
+        %h4.card-title
           Styling for
           = HackathonConfig['name']
         %h6.card-subtitle.mb-2.text-muted
@@ -114,7 +114,7 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title 
+        %h4.card-title
           Communications
         %h6.card-subtitle.mb-2.text-muted
           Get the word out.
@@ -146,7 +146,7 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title 
+        %h4.card-title
           Legal
         %h6.card-subtitle.mb-2.text-muted
           Agreements for your hackers.

--- a/app/views/manage/configs/index.html.haml
+++ b/app/views/manage/configs/index.html.haml
@@ -4,7 +4,8 @@
   .col-lg-6.mb-3
     .card.mb-3
       .card-body
-        %h4.card-title The Basics
+        %h4.card-title.font-weight-bold 
+          The Basics
         %h6.card-subtitle.mb-2.text-muted
           Core information about your hackathon.
         - @basics.each_entry do |key|
@@ -35,7 +36,7 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title
+        %h4.card-title.font-weight-bold
           Applying to
           = HackathonConfig['name']
         %h6.card-subtitle.mb-2.text-muted
@@ -76,7 +77,7 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title
+        %h4.card-title.font-weight-bold
           Styling for
           = HackathonConfig['name']
         %h6.card-subtitle.mb-2.text-muted
@@ -114,7 +115,36 @@
                     Open link
     .card.mb-3
       .card-body
-        %h4.card-title
+        %h4.card-title.font-weight-bold
+          Legal
+        %h6.card-subtitle.mb-2.text-muted
+          Agreements for your hackers.
+        - @legal.each_entry do |key|
+          - value = HackathonConfig[key]
+          %hr
+          %p.mb-1
+            = link_to edit_manage_config_path(key), class: 'icon-space-r' do
+              %span.fa.fa-pencil
+            %b
+              = t("simple_form.labels.hackathon_config.#{key}")
+          %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
+          %pre.mb-0= value
+          - if value.is_a?(String)
+            - images = ['.ico', '.jpg', '.jpeg', '.png', '.gif', '.svg'].freeze
+            - links = ['http://', 'https://'].freeze
+            - if value.end_with?(*images)
+              %br
+              = image_tag value, style: 'max-height: 100px;', class: 'img-thumbnail img-template'
+            - elsif value.start_with?(*links)
+              %br
+              = link_to value, target: 'blank' do
+                %span
+                  %span.fa.fa-external-link.icon-space-r-half
+                  Open link
+  .col-lg-6
+    .card.mb-3
+      .card-body
+        %h4.card-title.font-weight-bold
           Communications
         %h6.card-subtitle.mb-2.text-muted
           Get the word out.
@@ -144,77 +174,49 @@
                   %span
                     %span.fa.fa-external-link.icon-space-r-half
                     Open link
-    .card.mb-3
-      .card-body
-        %h4.card-title
-          Legal
-        %h6.card-subtitle.mb-2.text-muted
-          Agreements for your hackers.
-        - @legal.each_entry do |key|
-          - value = HackathonConfig[key]
+    .mb-3
+      .card.mb-3
+        .card-body
+          %h4.card-title.font-weight-bold
+            Environment Variables
+          %h6.card-subtitle.mb-2.text-muted
+            Environment variables are configured on the production server.
+          = render 'docs_link', title: 'Environment variable documentation', url: 'https://coderit.org/hackathon-manager/docs/deployment-environment-variables'
           %hr
-          %p.mb-1
-            = link_to edit_manage_config_path(key), class: 'icon-space-r' do
-              %span.fa.fa-pencil
-            %b
-              = t("simple_form.labels.hackathon_config.#{key}")
-          %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
-          %pre.mb-0= value
-          - if value.is_a?(String)
-            - images = ['.ico', '.jpg', '.jpeg', '.png', '.gif', '.svg'].freeze
-            - links = ['http://', 'https://'].freeze
-            - if value.end_with?(*images)
+          = render 'config_row', name: 'AWS S3 Bucket for Resumes', key: 'AWS_BUCKET'
+          = render 'config_row', name: 'AWS S3 Region', key: 'AWS_REGION'
+          = render 'config_row', name: 'AWS S3 Access Key ID', key: 'AWS_ACCESS_KEY_ID'
+          = render 'config_row', name: 'AWS S3 Secret Access Key', key: 'AWS_SECRET_ACCESS_KEY', secret: true
+          = render 'config_row', name: 'AWS S3 Endpoint', key: 'AWS_ENDPOINT', required: false
+          %hr
+          = render 'config_row', name: 'Domain Name', key: 'HM_DOMAIN_NAME'
+          = render 'config_row', name: 'Domain Protocol', key: 'HM_DOMAIN_PROTOCOL', default: 'https'
+          %hr
+          = render 'config_row', name: 'My MLH Application ID', key: 'MLH_KEY'
+          = render 'config_row', name: 'My MLH Secret', key: 'MLH_SECRET', secret: true
+          %hr
+          = render 'config_row', name: 'Rollbar Access Token', key: 'ROLLBAR_ACCESS_TOKEN', secret: true, required: false
+          %hr
+          = render 'config_row', name: 'Time Zone', key: 'TIME_ZONE', default: 'UTC', required: false
+          %hr
+          %p.mb-0
+            %b Email Provider
+          - if Rails.application.config.action_mailer.delivery_method == :smtp
+            %p
+              %span.badge.badge-secondary SendGrid
+              %span.badge.badge-success SMTP
               %br
-              = image_tag value, style: 'max-height: 100px;', class: 'img-thumbnail img-template'
-            - elsif value.start_with?(*links)
+              %small
+                %i To switch to SendGrid, unset the <code>SMTP_ADDRESS</code> environment variable
+            = render 'config_row', name: 'SMTP Address', key: 'SMTP_ADDRESS'
+            = render 'config_row', name: 'SMTP Port', key: 'SMTP_PORT', default: 587
+            = render 'config_row', name: 'SMTP Username', key: 'SMTP_USER_NAME', secret: true
+            = render 'config_row', name: 'SMTP Password', key: 'SMTP_PASSWORD', secret: true
+          - else
+            %p
+              %span.badge.badge-success SendGrid
+              %span.badge.badge-secondary SMTP
               %br
-              = link_to value, target: 'blank' do
-                %span
-                  %span.fa.fa-external-link.icon-space-r-half
-                  Open link
-
-  .col-lg-6.mb-3
-    .card.mb-3
-      .card-body
-        %h4.card-title Environment Variables
-        %h6.card-subtitle.mb-2.text-muted
-          Environment variables are configured on the production server.
-        = render 'docs_link', title: 'Environment variable documentation', url: 'https://coderit.org/hackathon-manager/docs/deployment-environment-variables'
-        %hr
-        = render 'config_row', name: 'AWS S3 Bucket for Resumes', key: 'AWS_BUCKET'
-        = render 'config_row', name: 'AWS S3 Region', key: 'AWS_REGION'
-        = render 'config_row', name: 'AWS S3 Access Key ID', key: 'AWS_ACCESS_KEY_ID'
-        = render 'config_row', name: 'AWS S3 Secret Access Key', key: 'AWS_SECRET_ACCESS_KEY', secret: true
-        = render 'config_row', name: 'AWS S3 Endpoint', key: 'AWS_ENDPOINT', required: false
-        %hr
-        = render 'config_row', name: 'Domain Name', key: 'HM_DOMAIN_NAME'
-        = render 'config_row', name: 'Domain Protocol', key: 'HM_DOMAIN_PROTOCOL', default: 'https'
-        %hr
-        = render 'config_row', name: 'My MLH Application ID', key: 'MLH_KEY'
-        = render 'config_row', name: 'My MLH Secret', key: 'MLH_SECRET', secret: true
-        %hr
-        = render 'config_row', name: 'Rollbar Access Token', key: 'ROLLBAR_ACCESS_TOKEN', secret: true, required: false
-        %hr
-        = render 'config_row', name: 'Time Zone', key: 'TIME_ZONE', default: 'UTC', required: false
-        %hr
-        %p.mb-0
-          %b Email Provider
-        - if Rails.application.config.action_mailer.delivery_method == :smtp
-          %p
-            %span.badge.badge-secondary SendGrid
-            %span.badge.badge-success SMTP
-            %br
-            %small
-              %i To switch to SendGrid, unset the <code>SMTP_ADDRESS</code> environment variable
-          = render 'config_row', name: 'SMTP Address', key: 'SMTP_ADDRESS'
-          = render 'config_row', name: 'SMTP Port', key: 'SMTP_PORT', default: 587
-          = render 'config_row', name: 'SMTP Username', key: 'SMTP_USER_NAME', secret: true
-          = render 'config_row', name: 'SMTP Password', key: 'SMTP_PASSWORD', secret: true
-        - else
-          %p
-            %span.badge.badge-success SendGrid
-            %span.badge.badge-secondary SMTP
-            %br
-            %small
-              %i To switch to SMTP, set the <code>SMTP_ADDRESS</code> environment variable
-          = render 'config_row', name: 'SendGrid API Key', key: 'SENDGRID_API_KEY', secret: true
+              %small
+                %i To switch to SMTP, set the <code>SMTP_ADDRESS</code> environment variable
+            = render 'config_row', name: 'SendGrid API Key', key: 'SENDGRID_API_KEY', secret: true

--- a/app/views/manage/configs/index.html.haml
+++ b/app/views/manage/configs/index.html.haml
@@ -2,24 +2,53 @@
 
 .row
   .col-lg-6.mb-3
-    - @config.each_key do |key|
-      - value = @config[key]
-      .card.mb-3
-        .card-body
+    .card.mb-3
+      .card-body
+        %h4.card-title The Basics
+        %h6.card-subtitle.mb-2.text-muted
+          Core information about your hackathon.
+        - @basics.each_entry do |key|
+          - value = HackathonConfig[key]
+          %hr
           %p.mb-1
             = link_to edit_manage_config_path(key), class: 'icon-space-r' do
               %span.fa.fa-pencil
             %b
               = t("simple_form.labels.hackathon_config.#{key}")
-            &nbsp;
-            %small
-              %code= key
           %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
-          - if key == 'custom_css'
-            %p
-              = link_to enter_theming_editor_manage_configs_path do
-                %span.fa.fa-paint-brush.icon-space-r-half
-                Interactive editor
+          - if value.nil? || value == ''
+            %p.mb-0
+              %span.badge.badge-secondary Not set
+          - else
+            %pre.mb-0= value
+            - if value.is_a?(String)
+              - images = ['.ico', '.jpg', '.jpeg', '.png', '.gif', '.svg'].freeze
+              - links = ['http://', 'https://'].freeze
+              - if value.end_with?(*images)
+                %br
+                = image_tag value, style: 'max-height: 100px;', class: 'img-thumbnail img-template'
+              - elsif value.start_with?(*links)
+                %br
+                = link_to value, target: 'blank' do
+                  %span
+                    %span.fa.fa-external-link.icon-space-r-half
+                    Open link
+    .card.mb-3
+      .card-body
+        %h4.card-title 
+          Applying to
+          = HackathonConfig['name']
+        %h6.card-subtitle.mb-2.text-muted
+          Configuring Questionnaires for your hackathon.
+        - @questionnaire_settings.each_entry do |key|
+          - value = HackathonConfig[key]
+          %hr
+          %p.mb-1
+            = link_to edit_manage_config_path(key), class: 'icon-space-r' do
+              %span.fa.fa-pencil
+            %b
+              = t("simple_form.labels.hackathon_config.#{key}")
+          %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
           - if key == 'disabled_fields'
             - cleaned_value = value
             - cleaned_value = cleaned_value.join(' ') if cleaned_value.is_a?(Array)
@@ -45,11 +74,109 @@
                   %span
                     %span.fa.fa-external-link.icon-space-r-half
                     Open link
+    .card.mb-3
+      .card-body
+        %h4.card-title 
+          Styling for
+          = HackathonConfig['name']
+        %h6.card-subtitle.mb-2.text-muted
+          Matching your hackathon's style.
+        - @styling.each_entry do |key|
+          - value = HackathonConfig[key]
+          %hr
+          %p.mb-1
+            = link_to edit_manage_config_path(key), class: 'icon-space-r' do
+              %span.fa.fa-pencil
+            %b
+              = t("simple_form.labels.hackathon_config.#{key}")
+          %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
+          - if key == 'custom_css'
+            %p
+              = link_to enter_theming_editor_manage_configs_path do
+                %span.fa.fa-paint-brush.icon-space-r-half
+                Interactive editor
+          - if value.nil? || value == ''
+            %p.mb-0
+              %span.badge.badge-secondary Not set
+          - else
+            %pre.mb-0= value
+            - if value.is_a?(String)
+              - images = ['.ico', '.jpg', '.jpeg', '.png', '.gif', '.svg'].freeze
+              - links = ['http://', 'https://'].freeze
+              - if value.end_with?(*images)
+                %br
+                = image_tag value, style: 'max-height: 100px;', class: 'img-thumbnail img-template'
+              - elsif value.start_with?(*links)
+                %br
+                = link_to value, target: 'blank' do
+                  %span
+                    %span.fa.fa-external-link.icon-space-r-half
+                    Open link
+    .card.mb-3
+      .card-body
+        %h4.card-title 
+          Communications
+        %h6.card-subtitle.mb-2.text-muted
+          Get the word out.
+        - @communications.each_entry do |key|
+          - value = HackathonConfig[key]
+          %hr
+          %p.mb-1
+            = link_to edit_manage_config_path(key), class: 'icon-space-r' do
+              %span.fa.fa-pencil
+            %b
+              = t("simple_form.labels.hackathon_config.#{key}")
+          %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
+          - if value.nil? || value == ''
+            %p.mb-0
+              %span.badge.badge-secondary Not set
+          - else
+            %pre.mb-0= value
+            - if value.is_a?(String)
+              - images = ['.ico', '.jpg', '.jpeg', '.png', '.gif', '.svg'].freeze
+              - links = ['http://', 'https://'].freeze
+              - if value.end_with?(*images)
+                %br
+                = image_tag value, style: 'max-height: 100px;', class: 'img-thumbnail img-template'
+              - elsif value.start_with?(*links)
+                %br
+                = link_to value, target: 'blank' do
+                  %span
+                    %span.fa.fa-external-link.icon-space-r-half
+                    Open link
+    .card.mb-3
+      .card-body
+        %h4.card-title 
+          Legal
+        %h6.card-subtitle.mb-2.text-muted
+          Agreements for your hackers.
+        - @legal.each_entry do |key|
+          - value = HackathonConfig[key]
+          %hr
+          %p.mb-1
+            = link_to edit_manage_config_path(key), class: 'icon-space-r' do
+              %span.fa.fa-pencil
+            %b
+              = t("simple_form.labels.hackathon_config.#{key}")
+          %p.text-muted= t("simple_form.hints.hackathon_config.#{key}").html_safe
+          %pre.mb-0= value
+          - if value.is_a?(String)
+            - images = ['.ico', '.jpg', '.jpeg', '.png', '.gif', '.svg'].freeze
+            - links = ['http://', 'https://'].freeze
+            - if value.end_with?(*images)
+              %br
+              = image_tag value, style: 'max-height: 100px;', class: 'img-thumbnail img-template'
+            - elsif value.start_with?(*links)
+              %br
+              = link_to value, target: 'blank' do
+                %span
+                  %span.fa.fa-external-link.icon-space-r-half
+                  Open link
 
   .col-lg-6.mb-3
     .card.mb-3
       .card-body
-        %h5.card-title Environment Variables
+        %h4.card-title Environment Variables
         %h6.card-subtitle.mb-2.text-muted
           Environment variables are configured on the production server.
         = render 'docs_link', title: 'Environment variable documentation', url: 'https://coderit.org/hackathon-manager/docs/deployment-environment-variables'


### PR DESCRIPTION
Adds section titles and subtitles for the settings page. Better organizes configs and removes excess information.

**Before**
<img width="1536" alt="Screen Shot 2020-11-29 at 9 18 11 PM" src="https://user-images.githubusercontent.com/22222538/100562019-65375c00-3288-11eb-9b57-6f02440c6578.png">

**After**
<img width="1536" alt="Screen Shot 2020-11-29 at 9 18 42 PM" src="https://user-images.githubusercontent.com/22222538/100562051-7718ff00-3288-11eb-95db-3dba47b036ea.png">

closes #239 

