### PR TITLE
fix: Fixes MyMLH branding in config

### DIFF
--- a/app/views/manage/configs/index.html.haml
+++ b/app/views/manage/configs/index.html.haml
@@ -63,8 +63,8 @@
         = render 'config_row', name: 'Domain Name', key: 'HM_DOMAIN_NAME'
         = render 'config_row', name: 'Domain Protocol', key: 'HM_DOMAIN_PROTOCOL', default: 'https'
         %hr
-        = render 'config_row', name: 'My MLH Application ID', key: 'MLH_KEY'
-        = render 'config_row', name: 'My MLH Secret', key: 'MLH_SECRET', secret: true
+        = render 'config_row', name: 'MyMLH Application ID', key: 'MLH_KEY'
+        = render 'config_row', name: 'MyMLH Secret', key: 'MLH_SECRET', secret: true
         %hr
         = render 'config_row', name: 'Rollbar Access Token', key: 'ROLLBAR_ACCESS_TOKEN', secret: true, required: false
         %hr


### PR DESCRIPTION
Removes an extra space in the MyMLH environment variables.

fixes #411 