### PR TITLE
fix(map): changed map overflow from scroll to auto

### DIFF
--- a/app/assets/stylesheets/manage.sass
+++ b/app/assets/stylesheets/manage.sass
@@ -55,7 +55,7 @@ $grey-med: #999
 
 #map
   text-align: center
-  overflow: scroll
+  overflow: auto
   width: 100%
 
 .dashboard-container-title


### PR DESCRIPTION
Overflow auto removed the unnecessary scroll bars around the map when on desktop but keeps them on mobile when they are needed 
before:
![image](https://user-images.githubusercontent.com/38338616/100554877-dfa2b480-3265-11eb-8d06-cae3618a5e3c.png)
after:
![image](https://user-images.githubusercontent.com/38338616/101832518-93792f00-3b05-11eb-9936-86dfd55817e9.png)
![firefox_2020-12-10_16-33-04](https://user-images.githubusercontent.com/38338616/101832545-9bd16a00-3b05-11eb-8897-7b87dfb37b4c.png)
