### PR TITLE
fix(questionnaire): missing information now in correct place

### DIFF
--- a/app/assets/javascripts/validate.js
+++ b/app/assets/javascripts/validate.js
@@ -22,7 +22,7 @@ document.addEventListener('turbolinks:load', function() {
                 $(this)
                   .parent()
                   .text()
-                  .includes('I have read and accepted')
+                  .includes('I read and accept')
               ) {
                 notify(".agreement_input", 'Please read & accept');
               } else {

--- a/app/assets/javascripts/validate.js
+++ b/app/assets/javascripts/validate.js
@@ -22,9 +22,9 @@ document.addEventListener('turbolinks:load', function() {
                 $(this)
                   .parent()
                   .text()
-                  .includes('I accept')
+                  .includes('I read and accept')
               ) {
-                notify(this, 'Please read & accept');
+                notify(".agreement_input", 'Please read & accept');
               } else {
                 notify(this, 'Missing Information');
               }
@@ -73,6 +73,13 @@ document.addEventListener('turbolinks:load', function() {
       }
       if (success) {
         $(this)
+          .parent()
+          .removeClass('field_with_errors')
+          .find('.error')
+          .fadeOut(200, function() {
+            $(this).remove();
+          });
+        $(".agreement_input")
           .parent()
           .removeClass('field_with_errors')
           .find('.error')

--- a/app/assets/javascripts/validate.js
+++ b/app/assets/javascripts/validate.js
@@ -22,7 +22,7 @@ document.addEventListener('turbolinks:load', function() {
                 $(this)
                   .parent()
                   .text()
-                  .includes('I read and accept')
+                  .includes('I have read and accepted')
               ) {
                 notify(".agreement_input", 'Please read & accept');
               } else {

--- a/app/views/questionnaires/_form.html.haml
+++ b/app/views/questionnaires/_form.html.haml
@@ -52,7 +52,8 @@
         %strong Agreements
         %p Please review the agreements and click the corresponding checkbox next to each agreement to agree.
         .form-inputs
-          = f.association :agreements, as: :check_boxes, label_method: :formatted_agreement, value_method: :id, label: "", wrapper_html: { style: 'display: block' }, input_html: { "data-validate" => "presence" }
+          .agreement_input
+            = f.association :agreements, as: :check_boxes, label_method: :formatted_agreement, value_method: :id, label: "", wrapper_html: { style: 'display: block' }, input_html: { "data-validate" => "presence" }
 
       .right
         %button.button{ type: "button", "data-wizard" => "previous" } Previous


### PR DESCRIPTION
it now displays the correct message "Please read & accept" instead of
missing information and the notification is now in the correct place

![image](https://user-images.githubusercontent.com/38338616/101957889-4ca43b80-3bd0-11eb-81ca-1d4ba33b22d1.png)
