### PR TITLE
fix: Shows questionnaires_closed_message on registration

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,7 +8,7 @@
     #disclaimer
       - if !HackathonConfig['accepting_questionnaires']
         .center
-          %strong We are no longer accepting applications. Thanks to everyone who applied!
+          %p= markdown(HackathonConfig['questionnaires_closed_message'])
         %br
       - if HackathonConfig['disclaimer_message'].present?
         = markdown(HackathonConfig['disclaimer_message'])


### PR DESCRIPTION
fixes #470 

fix: 
![Screen Shot 2020-12-18 at 1 45 40 AM](https://user-images.githubusercontent.com/22222538/102583469-bf328100-40d2-11eb-8e9f-bbb317a10d43.png)
