### PR TITLE
fix(hakiri): fix hakiri error with user input in html_safe

### DIFF
--- a/app/views/doorkeeper/authorizations/error.html.haml
+++ b/app/views/doorkeeper/authorizations/error.html.haml
@@ -6,5 +6,5 @@
     %p
       = @pre_auth.error_response.body[:error_description]
     %p
-      = t('doorkeeper.errors.messages.get_help', hackathon_name: content_tag(:strong, class: 'text-info') { HackathonConfig['name'] }).html_safe
+      = t('doorkeeper.errors.messages.get_help', hackathon_name: HackathonConfig['name'])
 


### PR DESCRIPTION
removed the html_safe. this no longer makes the hackathon name bold but removes the security error
Before
![image](https://user-images.githubusercontent.com/38338616/102650936-9f827380-4139-11eb-8598-6b7fc0ee8bfc.png)
After
![chrome_2020-12-18_13-59-59](https://user-images.githubusercontent.com/38338616/102650856-8aa5e000-4139-11eb-88d8-538308beca6e.png)
