### PR TITLE
develop <- master (2.1.2) backmerge

### DIFF
--- a/app/assets/javascripts/validate.js
+++ b/app/assets/javascripts/validate.js
@@ -18,13 +18,8 @@ document.addEventListener('turbolinks:load', function() {
         switch (types[i]) {
           case 'presence':
             if (!value || $.trim(value).length < 1) {
-              if (
-                $(this)
-                  .parent()
-                  .text()
-                  .includes('I read and accept')
-              ) {
-                notify(".agreement_input", 'Please read & accept');
+              if ($(this).parents('.agreement_input')) {
+                notify('.agreement_input', 'Please read & accept');
               } else {
                 notify(this, 'Missing Information');
               }

--- a/app/controllers/manage/agreements_controller.rb
+++ b/app/controllers/manage/agreements_controller.rb
@@ -20,27 +20,17 @@ class Manage::AgreementsController < Manage::ApplicationController
 
   # POST /agreements
   def create
-    if !agreement_params['agreement_url'].start_with?('http://', 'https://')
-      flash[:alert] = "Agreement URL must start with http:// or https://"
-      redirect_to new_manage_agreement_path
-    else
-      @agreement = Agreement.new(agreement_params)
-      @agreement.save
-      flash[:notice] = "#{@agreement.name} was successfully created."
-      redirect_to manage_agreements_path
-    end
+    @agreement = Agreement.new(agreement_params)
+    @agreement.save
+    flash[:notice] = "#{@agreement.name} was successfully created."
+    redirect_to manage_agreements_path
   end
 
   # PATCH/PUT /agreements/1
   def update
-    if !agreement_params['agreement_url'].nil? && !agreement_params['agreement_url'].start_with?('http://', 'https://')
-      flash[:alert] = "Agreement URL must start with http:// or https://"
-      redirect_to edit_manage_agreement_url
-    else
-      @agreement.update_attributes(agreement_params)
-      flash[:notice] = nil
-      redirect_to manage_agreements_path
-    end
+    @agreement.update_attributes(agreement_params)
+    flash[:notice] = nil
+    redirect_to manage_agreements_path
   end
 
   # DELETE /agreements/1
@@ -60,7 +50,7 @@ class Manage::AgreementsController < Manage::ApplicationController
   # Only allow a trusted parameter "white list" through.
   def agreement_params
     params.require(:agreement).permit(
-      :name, :agreement_url
+      :name, :agreement
     )
   end
 end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,13 +1,14 @@
 class Agreement < ApplicationRecord
   include ActionView::Helpers::UrlHelper
   validates_presence_of :name
-  validates_presence_of :agreement_url
+  validates_presence_of :agreement
 
   strip_attributes
 
   has_and_belongs_to_many :questionnaires
 
   def formatted_agreement
-    "<p>I read and accept the&nbsp;#{link_to name, agreement_url, target: '_blank'}&nbsp;agreement.</p>".html_safe
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
+    markdown.render(agreement).gsub("<a href=", "<a target=\“_blank\” rel=\"noreferrer noopener\" href=").html_safe
   end
 end

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -43,8 +43,7 @@ class Questionnaire < ApplicationRecord
 
   validates :portfolio_url, url: { allow_blank: true }
   validates :vcs_url, url: { allow_blank: true }
-  validates_format_of :vcs_url, with: %r{((github.com\/\w+\/?)|(gitlab.com\/\w+\/?)|(bitbucket.org\/\w+\/?))}, allow_blank: true, message: "Must be a GitHub, GitLab or Bitbucket url"
-
+  validates_format_of :vcs_url, with: %r{\A(((https?:\/\/)?(www\.)?github\.com\/\w+\/?)|((https?:\/\/)?(www\.)?gitlab\.com\/\w+\/?)|((https?:\/\/)?(www\.)?bitbucket\.org\/\w+\/?))\z}, allow_blank: true, message: "Must be a GitHub, GitLab or Bitbucket url"
   strip_attributes
 
   POSSIBLE_EXPERIENCES = {
@@ -135,7 +134,7 @@ class Questionnaire < ApplicationRecord
   end
 
   def vcs_url=(value)
-    value = "http://" + value if !value.blank? && !value.include?("http://") && !value.include?("https://")
+    value = "https://" + value if !value.blank? && !value.include?("http://") && !value.include?("https://")
     super value
   end
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,7 +8,7 @@
     #disclaimer
       - if !HackathonConfig['accepting_questionnaires']
         .center
-          %strong We are no longer accepting applications. Thanks to everyone who applied!
+          %p= markdown(HackathonConfig['questionnaires_closed_message'])
         %br
       - if HackathonConfig['disclaimer_message'].present?
         = markdown(HackathonConfig['disclaimer_message'])

--- a/app/views/doorkeeper/authorizations/error.html.haml
+++ b/app/views/doorkeeper/authorizations/error.html.haml
@@ -6,5 +6,5 @@
     %p
       = @pre_auth.error_response.body[:error_description]
     %p
-      = raw t('doorkeeper.errors.messages.get_help', hackathon_name: content_tag(:strong, class: 'text-info') { HackathonConfig['name'] })
+      = t('doorkeeper.errors.messages.get_help', hackathon_name: HackathonConfig['name'])
 

--- a/app/views/manage/agreements/_form.html.haml
+++ b/app/views/manage/agreements/_form.html.haml
@@ -4,7 +4,7 @@
 
     .form-inputs
       = f.input :name
-      = f.input :agreement_url, hint: "Should be a full https:// URL to a web page or .pdf file", label: t(:agreement_url, scope: 'pages.manage.agreements')
+      = f.input :agreement, label: t(:agreement, scope: 'pages.manage.agreements'), input_html: { rows: 10, 'data-simple-mde' => '1' }
 
     .form-actions
       = f.button :submit, class: 'btn-primary'

--- a/app/views/manage/agreements/index.html.haml
+++ b/app/views/manage/agreements/index.html.haml
@@ -12,7 +12,7 @@
         %th
           = t(:name, scope: 'pages.manage.agreements')
         %th
-          = t(:agreement_url, scope: 'pages.manage.agreements')
+          = t(:agreement, scope: 'pages.manage.agreements')
 
     %tbody
       - @agreements.each do |agreement|
@@ -25,4 +25,4 @@
             %strong
               = agreement.name
           %td
-            = agreement.agreement_url
+            = markdown(agreement.agreement)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,8 +54,6 @@ en:
         trigger: Sent automatically when a new or updated applicant matches this criteria. Does not send to anyone already matching this criteria.
       school:
         is_home: The "home" school is separated from all other schools on dashboard metrics.
-      agreement:
-        name: 'Agreements are displayed to applicants as: "I read & accept the [agreement_name] agreement"'
       hackathon_config:
         accepting_questionnaires: Specify and allow questionnaires to be accepted.
         digital_hackathon: Optimize HackathonManager for a digital hackathon. (Removes travel, dietary restrictions, etc.)
@@ -192,7 +190,7 @@ en:
         title: Legal Agreements
         notice: "These are legal agreements that are required to be reviewed and agreed upon by all applicants of %{hackathon_name}."
         name: Name
-        agreement_url: Agreement URL
+        agreement: Agreement
         new: New Agreement
         edit: Edit Agreement
       settings:

--- a/db/migrate/20201218010133_convert_agreements_to_text.rb
+++ b/db/migrate/20201218010133_convert_agreements_to_text.rb
@@ -1,0 +1,11 @@
+class ConvertAgreementsToText < ActiveRecord::Migration[5.2]
+  def self.up
+    change_column :agreements, :agreement_url, :text
+    rename_column :agreements, :agreement_url, :agreement
+  end
+
+  def self.down
+    rename_column :agreements, :agreement, :agreement_url
+    change_column :agreements, :agreement_url, :sring
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_053827) do
+ActiveRecord::Schema.define(version: 2020_12_18_010133) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
 
   create_table "agreements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
-    t.string "agreement_url"
+    t.text "agreement"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -73,7 +73,9 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
     t.integer "query_id"
     t.text "statement"
     t.string "data_source"
-    t.datetime "created_at"
+    t.timestamp "created_at"
+    t.index ["query_id"], name: "index_blazer_audits_on_query_id"
+    t.index ["user_id"], name: "index_blazer_audits_on_user_id"
   end
 
   create_table "blazer_checks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -84,9 +86,11 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
     t.text "emails"
     t.string "check_type"
     t.text "message"
-    t.datetime "last_run_at"
+    t.timestamp "last_run_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_checks_on_creator_id"
+    t.index ["query_id"], name: "index_blazer_checks_on_query_id"
   end
 
   create_table "blazer_dashboard_queries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -95,6 +99,8 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["dashboard_id"], name: "index_blazer_dashboard_queries_on_dashboard_id"
+    t.index ["query_id"], name: "index_blazer_dashboard_queries_on_query_id"
   end
 
   create_table "blazer_dashboards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -102,6 +108,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
     t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_dashboards_on_creator_id"
   end
 
   create_table "blazer_queries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -112,6 +119,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
     t.string "data_source"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
   end
 
   create_table "bus_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -151,9 +159,9 @@ ActiveRecord::Schema.define(version: 2020_12_09_053827) do
     t.string "subject"
     t.string "recipients"
     t.text "body"
-    t.datetime "queued_at"
-    t.datetime "started_at"
-    t.datetime "delivered_at"
+    t.timestamp "queued_at"
+    t.timestamp "started_at"
+    t.timestamp "delivered_at"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "template", default: "default"

--- a/test/controllers/manage/agreements_controller_test.rb
+++ b/test/controllers/manage/agreements_controller_test.rb
@@ -191,7 +191,7 @@ class Manage::AgreementsControllerTest < ActionController::TestCase
     end
 
     should "create a new agreement" do
-      post :create, params: { agreement: { name: "Fun Agreement", agreement_url: "https://foo.com" } }
+      post :create, params: { agreement: { name: "Fun Agreement", agreement: "Please read and accept https://foo.com" } }
       assert_response :redirect
     end
 
@@ -204,11 +204,6 @@ class Manage::AgreementsControllerTest < ActionController::TestCase
       patch :update, params: { id: @agreement, agreement: { name: "New agreement Name" } }
       assert_response :redirect
       assert_redirected_to manage_agreements_path
-    end
-
-    should "enforce agreement_url to be a link" do
-      patch :update, params: { id: @agreement, agreement: { name: "New agreement Name", agreement_url: "hello" } }
-      assert_response :redirect
     end
 
     context "#destroy" do

--- a/test/factories/agreement.rb
+++ b/test/factories/agreement.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :agreement do
     name { "HackFoo Agreement" }
-    agreement_url { "https://www.foo.com" }
+    agreement { "Please read and accept https://www.foo.com" }
   end
 end

--- a/test/models/agreement_test.rb
+++ b/test/models/agreement_test.rb
@@ -4,10 +4,10 @@ class AgreementTest < ActiveSupport::TestCase
   should have_and_belong_to_many :questionnaires
 
   should strip_attribute :name
-  should strip_attribute :agreement_url
+  should strip_attribute :agreement
 
   should validate_presence_of :name
-  should validate_presence_of :agreement_url
+  should validate_presence_of :agreement
 
   should "not allow questionnaires to accept agreements for others" do
     @questionnaire1 = create(:questionnaire)


### PR DESCRIPTION
This marks the change of no longer using version branches for HM, and using `develop` as our main dev branch!

* fix(questionnaire): missing information now in correct place (#443)

* fix(questionnair): missing information now in correct place

it now displays the correct message "Please read & accept" instead of
missing information and the notification is now in the correct place

* Update app/assets/javascripts/validate.js

* Revert "Update app/assets/javascripts/validate.js"

This reverts commit bc54783f94d7a249ae878ad4ead6a9fb2173fee7.

Signed-off-by: Peter Kos <pkos91@icloud.com>

Co-authored-by: Peter Kos <pkos91@icloud.com>

* fix: Fixes mobile agreements layout bug

Signed-off-by: Peter Kos <pkos91@icloud.com>

* feat: Removes semantic-release (#446)

* refactor: Moves CI to develop branch (#449)

Co-authored-by: Peter Kos <pkos91@icloud.com>

* build: Merges 2.1.2 into develop

* fix(hakiri): corrected unescaped model attribute

* fix(hakiri): added html_safe to show proper output

Co-authored-by: Jeremy Rudman <jeremyrudman@gmail.com>
Co-authored-by: JeremyRudman <38338616+JeremyRudman@users.noreply.github.com>

* fix: Shows questionnaires_closed_message on registration

* feat: Allows agreements to be fully customizable (#465)

* feat: Allows agreements to be fully customizable

* fix: Fixes broken migrations

* fix: Migrations misname issue

* feat: Forces agreement links to open in new tab

* Agreement validation detection fixed

Signed-off-by: Peter Kos <pkos91@icloud.com>

* refactor: Removes old input hint

Co-authored-by: Peter Kos <pkos91@icloud.com>

* fix(hakiri): fixed un-escaped regex for vcs link (#467)

* fix(hakiri): corrected unescaped model attribute

* fix(hakiri): added html_safe to show proper output

* fix(hakiri): added \A \z to regex

* fix(questionnaire): fixed hakiri error with vcs link regex

* fix(questionnaire): fixed houndci commplaint

Co-authored-by: Chris Baudouin, Jr <cjb5326@rit.edu>

* fix(hakiri): fix hakiri error with user input in html_safe (#475)

Co-authored-by: Peter Kos <pkos91@icloud.com>

Co-authored-by: JeremyRudman <38338616+JeremyRudman@users.noreply.github.com>
Co-authored-by: Chris Baudouin, Jr <cjb5326@rit.edu>
Co-authored-by: Jeremy Rudman <jeremyrudman@gmail.com>