### PR TITLE
fix: Resolves issue preventing new MyMLH users from creating questionnaires

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -29,23 +29,24 @@ class QuestionnairesController < ApplicationController
 
     if session["devise.provider_data"] && session["devise.provider_data"]["info"]
       info = session["devise.provider_data"]["info"]
-      if all_my_mlh_fields_provided?
-        @skip_my_mlh_fields = true
-        @questionnaire.tap do |q|
-          q.phone          = info["phone_number"]
-          q.level_of_study = info["level_of_study"]
-          q.major          = info["major"]
-          q.date_of_birth  = info["date_of_birth"]
-          q.gender         = info["gender"]
+      @skip_my_mlh_fields = true
+      if !all_my_mlh_fields_provided?
+        flash[:notice] = nil
+        flash[:alert] = t(:my_mlh_null, scope: 'errors')
+      end
+      @questionnaire.tap do |q|
+        q.phone          = info["phone_number"]
+        q.level_of_study = info["level_of_study"]
+        q.major          = info["major"]
+        q.date_of_birth  = info["date_of_birth"]
+        q.gender         = info["gender"]
 
+        if info["school"]
           school = School.where(name: info["school"]["name"]).first_or_create do |s|
             s.name = info["school"]["name"]
           end
           q.school_id = school.id
         end
-      else
-        flash[:notice] = nil
-        flash[:alert] = t(:my_mlh_null, scope: 'errors')
       end
     end
 

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -30,7 +30,7 @@ class QuestionnairesController < ApplicationController
     if session["devise.provider_data"] && session["devise.provider_data"]["info"]
       info = session["devise.provider_data"]["info"]
       @skip_my_mlh_fields = true
-      if !all_my_mlh_fields_provided?
+      unless all_my_mlh_fields_provided?
         flash[:notice] = nil
         flash[:alert] = t(:my_mlh_null, scope: 'errors')
       end

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -133,15 +133,9 @@ class QuestionnairesController < ApplicationController
   def all_my_mlh_fields_provided?
     info = session["devise.provider_data"]["info"]
 
-    return false if info["phone_number"].blank?
-    return false if info["level_of_study"].blank?
-    return false if info["major"].blank?
-    return false if info["date_of_birth"].blank?
-    return false if info["gender"].blank?
-    return false if info["school"].blank?
-    return false if info["school"]["name"].blank?
-
-    true
+    return true unless info["phone_number"].blank? || info["level_of_study"].blank? || info["major"].blank? ||
+                       info["date_of_birth"].blank? || info["gender"].blank? || info["school"].blank? ||
+                       info["school"]["name"].blank?
   end
 
   def questionnaire_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
     registrations:
       user:
         signed_up: Welcome! Your account has been created.
+  errors:
+    my_mlh_null: Failed to retrieve application information from MyMLH, please continue manually.
   simple_form:
     hints:
       bus_list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
       user:
         signed_up: Welcome! Your account has been created.
   errors:
-    my_mlh_null: Failed to retrieve application information from MyMLH, please continue manually.
+    my_mlh_null: Some information from MyMLH is missing, please fill in the missing fields.
   simple_form:
     hints:
       bus_list:
@@ -138,7 +138,7 @@ en:
         title: Bus Lists
       schools:
         title: Schools
-      users: 
+      users:
         title: Users & Staff
         users: All Users
         staff: "%{hackathon_name} Staff"


### PR DESCRIPTION
Checks to see if any of the required MyMLH data is null. If true, we display an error that instructs the user to continue manually. 

![image](https://user-images.githubusercontent.com/22222538/103726568-35762500-4fa7-11eb-8575-f7c81dabfdac.png)

fixes #515 


Edit flow: 

After you auth via MyMLH, it will attempt to skip the first page, whether the info exists or not, triggering the frontend validation.
If no info is missing, it will skip to page 2 of the questionnaire form.
<img src="https://user-images.githubusercontent.com/2782749/103733761-70348900-4fb8-11eb-88ef-0f80a5190e44.png" width="500px" />

If info is missing, due to the triggered validation, it will **attempt to pull as many fields as possible**, and highlight the missing field(s):
<img src="https://user-images.githubusercontent.com/2782749/103734024-0b2d6300-4fb9-11eb-94ec-0f37142dc783.png" width="500px" />