### PR TITLE
fix: vcs url error not displaying in edit application page

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -84,12 +84,13 @@ class QuestionnairesController < ApplicationController
     update_params = questionnaire_params
     update_params = convert_school_name_to_id(update_params)
 
+    @agreements = Agreement.all
     respond_to do |format|
       if @questionnaire.update_attributes(update_params)
         format.html { redirect_to questionnaires_path, notice: 'Application was successfully updated.' }
         format.json { head :no_content }
       else
-        format.html { redirect_to edit_questionnaires_url }
+        format.html { render action: "edit" }
         format.json { render json: @questionnaire.errors, status: :unprocessable_entity }
       end
     end


### PR DESCRIPTION
Fixes #492 
changed from redirect_to to render "edit" on error. redirect_to makes a fresh request which causes the error information to be lost well render keeps the information

![chrome_2021-01-04_23-23-37](https://user-images.githubusercontent.com/38338616/103606637-ea93d900-4ee4-11eb-81a5-7b6a2293c32a.png)