### PR TITLE
fix: Resolves job execution failure on nil questionnaires

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -23,7 +23,7 @@ class UserMailer < ApplicationMailer
 
   def rsvp_reminder_email(user_id)
     @user = User.find_by_id(user_id)
-    return if @user.blank? || !@user.questionnaire.acc_status == "accepted" || Time.now.in_time_zone.to_date > Date.parse(HackathonConfig["event_start_date"]).in_time_zone.to_date
+    return if @user.blank? || @user.questionnaire.blank? || !@user.questionnaire.acc_status == "accepted" || Time.now.in_time_zone.to_date > Date.parse(HackathonConfig["event_start_date"]).in_time_zone.to_date
 
     Message.queue_for_trigger("questionnaire.rsvp_reminder", @user.id)
   end


### PR DESCRIPTION
Simple blank? check to make sure the questionnaire isn't nil before we execute the RSVP reminder email job. This is currently causing failing jobs in Sidekiq. 

fixes #528 