### PR TITLE
fix(questionnaire): fixed whitespace and readded agreements to edit page

### DIFF
--- a/app/views/manage/questionnaires/_form.html.haml
+++ b/app/views/manage/questionnaires/_form.html.haml
@@ -39,7 +39,7 @@
         .card.mb-4
           .card-header Agreements
           .card-body
-            = f.association :agreements, as: :check_boxes, label_method: :formatted_agreement, value_method: :id, disabled: true, label: false, hint: "Only account owners can accept questionnaires"
+            = f.association :agreements, as: :check_boxes, label_method: :formatted_agreement, value_method: :id, disabled: true, label: false, hint: "Only account owners can accept legal agreements"
 
 
       .col-xl-6

--- a/app/views/manage/questionnaires/_form.html.haml
+++ b/app/views/manage/questionnaires/_form.html.haml
@@ -36,6 +36,12 @@
               = f.input :boarded_bus, as: :boolean, label: "Boarded bus", input_html: { checked: @questionnaire.boarded_bus_at.present? }
               = f.input :is_bus_captain, label: "Is Bus Captain"
 
+        .card.mb-4
+          .card-header Agreements
+          .card-body
+            = f.association :agreements, as: :check_boxes, label_method: :formatted_agreement, value_method: :id, disabled: true, label: false, hint: "Only account owners can accept questionnaires"
+
+
       .col-xl-6
         .card.mb-4
           .card-header Special notices

--- a/app/views/manage/questionnaires/_form.html.haml
+++ b/app/views/manage/questionnaires/_form.html.haml
@@ -41,7 +41,6 @@
           .card-body
             = f.association :agreements, as: :check_boxes, label_method: :formatted_agreement, value_method: :id, disabled: true, label: false, hint: "Only account owners can accept legal agreements"
 
-
       .col-xl-6
         .card.mb-4
           .card-header Special notices


### PR DESCRIPTION
fixed the whitespace which was caused by label being a empty string instead of false so the label space was still there. The agreements were also re added although disabled for a director to change.

new:
![chrome_2021-02-08_13-41-19](https://user-images.githubusercontent.com/38338616/107268314-fc055f00-6a15-11eb-8048-28e59a23a2b9.png)

previous:
![chrome_2021-02-08_12-42-53](https://user-images.githubusercontent.com/38338616/107268393-10495c00-6a16-11eb-99e3-aa606cd6cff7.png)

possible alternative:
![chrome_2021-02-08_12-43-07](https://user-images.githubusercontent.com/38338616/107268426-1e977800-6a16-11eb-8a2f-a25e67be8745.png)
 
