### PR TITLE
refactor(questionnaire): changed questionnaire missing info error

### DIFF
--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -22,8 +22,7 @@ class Questionnaire < ApplicationRecord
   validates_uniqueness_of :user_id
 
   validates_presence_of :phone, :date_of_birth, :school_id, :experience, :shirt_size, :interest
-  validates_presence_of :gender, :major, :level_of_study, :graduation_year, :race_ethnicity
-  validates :country, presence:  { message: %[information is missing from application. Please update your <a href="#{Rails.application.routes.url_helpers.edit_questionnaires_path}">Application</a>] }
+  validates_presence_of :gender, :major, :level_of_study, :graduation_year, :race_ethnicity, :country
 
   DIETARY_SPECIAL_NEEDS_MAX_LENGTH = 500
   validates_length_of :dietary_restrictions, maximum: DIETARY_SPECIAL_NEEDS_MAX_LENGTH

--- a/app/views/rsvps/show.html.haml
+++ b/app/views/rsvps/show.html.haml
@@ -2,6 +2,8 @@
 .form-container
   - if @questionnaire.unaccepted_agreements.any?
     = render partial: 'unaccepted_agreements_notice'
+  - if @questionnaire.country.blank?
+    = render partial: 'missing_country_notice'
 = simple_form_for @questionnaire, url: url_for(controller: "rsvps", action: "update"), html: { "data-validate" => "form" } do |f|
   .form-container
     #disclaimer
@@ -41,7 +43,7 @@
         .hide-if-not-attending{ style: @questionnaire.acc_status == "rsvp_denied" ? "display: none;" : "" }
           = f.input :phone, input_html: { "data-validate" => "presence" }, label: "Please verify your phone number:"
 
-      = f.button :submit, value: "Update"
+      = f.button :submit, value: "Update", disabled: @questionnaire.invalid?
 
   - if BusList.any? && !HackathonConfig['digital_hackathon']
     .form-container.hide-if-not-attending{ style: @questionnaire.acc_status == "rsvp_denied" ? "display: none;" : "" }
@@ -75,7 +77,7 @@
         %p
           %small If you sign up for a bus not stopping at your school, you are responsible for transportation to & from a pick-up location.
 
-        = f.button :submit, value: "Update"
+        = f.button :submit, value: "Update", disabled: @questionnaire.invalid?
         %br
         - if @questionnaire.bus_list_id && @questionnaire.is_bus_captain?
           %p= link_to "Bus Captain Dashboard &raquo;".html_safe, bus_list_path


### PR DESCRIPTION
the error is now in a box like that of agreements and not the custom error message from the model. also disabled rsvp and bus update button if the user questionnaire is invalid. 

![firefox_2021-02-08_23-59-35](https://user-images.githubusercontent.com/38338616/107318302-74960b00-6a6a-11eb-8067-af3d0c5cb120.png)
