### PR TITLE
fix(schedule): orginizers now have read only access

### DIFF
--- a/app/controllers/manage/events_controller.rb
+++ b/app/controllers/manage/events_controller.rb
@@ -1,5 +1,6 @@
 class Manage::EventsController < Manage::ApplicationController
-  before_action :require_director
+  before_action :require_director_or_organizer, only: :index
+  before_action :require_director, except: :index
   respond_to :html, :json
 
   def index

--- a/test/controllers/manage/events_controller_test.rb
+++ b/test/controllers/manage/events_controller_test.rb
@@ -138,10 +138,9 @@ class Manage::EventsControllerTest < ActionController::TestCase
       sign_in @user
     end
 
-    should "not allow access to manage_events#index" do
+    should "allow access to manage_events#index" do
       get :index
-      assert_response :redirect
-      assert_redirected_to manage_root_path
+      assert_response :success
     end
 
     should "not allow access to manage_events#show" do


### PR DESCRIPTION
known issue: organizers clicking on a event item brings them to the dashboard as they don't have edit permissions