### PR TITLE
build(deps): Updates GitHub Actions to cache gems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
       uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
     - name: Install gems
       run: |
           gem install pkg-config


### PR DESCRIPTION
Caches the Ruby gems to prevent installs for each run.