### PR TITLE
feat: Adds API support for checking attendees in

### DIFF
--- a/app/controllers/manage/questionnaires_controller.rb
+++ b/app/controllers/manage/questionnaires_controller.rb
@@ -66,34 +66,43 @@ class Manage::QuestionnairesController < Manage::ApplicationController
   end
 
   def check_in
-    redirect_to_checkins = params[:redirect_to_checkins] || false
-    show_redirect_path = redirect_to_checkins ? manage_checkin_path(@questionnaire) : manage_questionnaire_path(@questionnaire)
-    index_redirect_path = redirect_to_checkins ? manage_checkins_path : manage_questionnaires_path
-    if params[:check_in] == "true"
-      if params[:questionnaire]
-        q_params = params.require(:questionnaire).permit(:phone, :can_share_info, :email)
-        email = q_params.delete(:email)
-        @questionnaire.update_attributes(q_params)
-        @questionnaire.user.update_attributes(email: email)
-      end
-      unless @questionnaire.valid?
-        flash[:alert] = @questionnaire.errors.full_messages.join(", ")
-        redirect_to show_redirect_path
-        return
-      end
-      @questionnaire.update_attribute(:checked_in_at, Time.now)
-      @questionnaire.update_attribute(:checked_in_by_id, current_user.id)
-      flash[:notice] = "Checked in #{@questionnaire.user.full_name}."
-    elsif params[:check_in] == "false"
-      @questionnaire.update_attribute(:checked_in_at, nil)
-      @questionnaire.update_attribute(:checked_in_by_id, current_user.id)
-      flash[:notice] = "#{@questionnaire.user.full_name} no longer checked in."
-    else
-      flash[:alert] = "No check-in action provided!"
-      redirect_to show_redirect_path
-      return
+    respond_to do |format|
+      format.json {
+        if params[:check_in] == "true"
+          check_in_attendee
+        elsif params[:check_in] == "false"
+          check_out_attendee
+        end
+      }
+      format.html {
+        redirect_to_checkins = params[:redirect_to_checkins] || false
+        show_redirect_path = redirect_to_checkins ? manage_checkin_path(@questionnaire) : manage_questionnaire_path(@questionnaire)
+        index_redirect_path = redirect_to_checkins ? manage_checkins_path : manage_questionnaires_path
+        if params[:check_in] == "true"
+          if params[:questionnaire]
+            q_params = params.require(:questionnaire).permit(:phone, :can_share_info, :email)
+            email = q_params.delete(:email)
+            @questionnaire.update_attributes(q_params)
+            @questionnaire.user.update_attributes(email: email)
+          end
+          unless @questionnaire.valid?
+            flash[:alert] = @questionnaire.errors.full_messages.join(", ")
+            redirect_to show_redirect_path
+            return
+          end
+          check_in_attendee
+          flash[:notice] = "Checked in #{@questionnaire.user.full_name}."
+        elsif params[:check_in] == "false"
+          check_out_attendee
+          flash[:notice] = "#{@questionnaire.user.full_name} no longer checked in."
+        else
+          flash[:alert] = "No check-in action provided!"
+          redirect_to show_redirect_path
+          return
+        end
+        redirect_to index_redirect_path
+      }
     end
-    redirect_to index_redirect_path
   end
 
   def destroy
@@ -146,6 +155,16 @@ class Manage::QuestionnairesController < Manage::ApplicationController
   end
 
   private
+
+  def check_in_attendee
+    @questionnaire.update_attribute(:checked_in_at, Time.now)
+    @questionnaire.update_attribute(:checked_in_by_id, current_user.id)
+  end
+
+  def check_out_attendee
+    @questionnaire.update_attribute(:checked_in_at, nil)
+    @questionnaire.update_attribute(:checked_in_by_id, current_user.id)
+  end
 
   def questionnaire_params
     # Note that this ONLY considers parameters for the questionnaire, not the user.

--- a/app/controllers/manage/questionnaires_controller.rb
+++ b/app/controllers/manage/questionnaires_controller.rb
@@ -67,14 +67,14 @@ class Manage::QuestionnairesController < Manage::ApplicationController
 
   def check_in
     respond_to do |format|
-      format.json {
+      format.json do
         if params[:check_in] == "true"
           check_in_attendee
         elsif params[:check_in] == "false"
           check_out_attendee
         end
-      }
-      format.html {
+      end
+      format.html do
         redirect_to_checkins = params[:redirect_to_checkins] || false
         show_redirect_path = redirect_to_checkins ? manage_checkin_path(@questionnaire) : manage_questionnaire_path(@questionnaire)
         index_redirect_path = redirect_to_checkins ? manage_checkins_path : manage_questionnaires_path
@@ -101,7 +101,7 @@ class Manage::QuestionnairesController < Manage::ApplicationController
           return
         end
         redirect_to index_redirect_path
-      }
+      end
     end
   end
 

--- a/test/controllers/manage/questionnaires_controller_test.rb
+++ b/test/controllers/manage/questionnaires_controller_test.rb
@@ -359,13 +359,27 @@ class Manage::QuestionnairesControllerTest < ActionController::TestCase
       end
     end
 
-    should "check in the questionnaire" do
-      patch :check_in, params: { id: @questionnaire, check_in: "true" }
+    should "check in the questionnaire through html" do
+      patch :check_in, params: { id: @questionnaire, check_in: "true" }, format: :html
       assert 1.minute.ago < @questionnaire.reload.checked_in_at
       assert_equal @user.id, @questionnaire.reload.checked_in_by_id
       assert_match /Checked in/, flash[:notice]
       assert_response :redirect
       assert_redirected_to manage_questionnaires_path
+    end
+
+    should "check in the questionnaire through api" do
+      patch :check_in, params: { id: @questionnaire, check_in: "true" }, format: :json
+      assert 1.minute.ago < @questionnaire.reload.checked_in_at
+      assert_equal @user.id, @questionnaire.reload.checked_in_by_id
+      assert_response :success
+    end
+
+    should "check out the questionnaire through api" do
+      patch :check_in, params: { id: @questionnaire, check_in: "false" }, format: :json
+      assert_nil @questionnaire.reload.checked_in_at
+      assert_equal @user.id, @questionnaire.reload.checked_in_by_id
+      assert_response :success
     end
 
     should "check in the questionnaire and update information" do


### PR DESCRIPTION
Adds proper API support for the check_in route, accessing the route through the API format will no longer respond with a redirect and will respond with a 204 upon success.  

closes #615 