### PR TITLE
fix: Fixes missing name error and race condition in data exports

### DIFF
--- a/app/jobs/generate_data_export_job.rb
+++ b/app/jobs/generate_data_export_job.rb
@@ -54,10 +54,10 @@ class GenerateDataExportJob < ApplicationJob
       resume_paths = []
       questionnaires.each do |q|
         csv_row = [
-          q.first_name,
-          q.last_name,
+          q.user.first_name,
+          q.user.last_name,
+          q.user.email,
           q.school_name,
-          q.email,
           q.vcs_url,
           q.portfolio_url,
         ]
@@ -81,7 +81,7 @@ class GenerateDataExportJob < ApplicationJob
       csvfile_name = "000-Attendees.csv"
       csvfile_path = File.join(folder_path, csvfile_name)
       CSV.open(csvfile_path, "wb") do |csv|
-        csv << ["Fist name", "Last name", "School", "Email", "VCS URL", "Portfolio URL", "Resume filename"]
+        csv << ["First name", "Last name", "Email", "School", "VCS URL", "Portfolio URL", "Resume Filename"]
         csv_data.each do |row|
           csv << row
         end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -40,8 +40,8 @@ class DataExport < ApplicationRecord
   def enqueue!
     raise "Data export has already been queued" unless status == "created_not_queued"
 
-    GenerateDataExportJob.perform_later(self)
     update_attribute(:queued_at, Time.now)
+    GenerateDataExportJob.perform_later(self)
   end
 
   def status


### PR DESCRIPTION
Fixes missing user's name migration from #222, fixes race condition where the controller wasn't updating the queued_at timestamp before the job started. This caused the job to think it was a duplicate export.

fixes #534