### PR TITLE
ci: Swap HoundCI to use ESLint instead of JSHint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "rules": {},
+    "env": {
+      "es6": true,
+      "node": true,
+      "browser": true
+    },
+    "extends": "eslint:recommended"
+  }
+  

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,5 @@
       "browser": true
     },
     "extends": "eslint:recommended"
-  }
+}
   

--- a/.hound.yml
+++ b/.hound.yml
@@ -2,5 +2,8 @@ ruby:
   config_file: .rubocop.yml
 haml:
   config_file: .haml-lint.yml
-eslint:
+javascript:
   enabled: false
+eslint:
+  enabled: true
+  config_file: .eslintrc


### PR DESCRIPTION
## Background

Setup HoundCI to support newer JS features, such as those used in our new Vue frontend project.

## Contents
- Configured HoundCI to use ESLint with the default linting config
