### PR TITLE
ci: Swap HoundCI to use ESLint instead of JSHint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "rules": {},
+    "env": {
+        "es6": true,
+        "node": true,
+        "browser": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/.hound.yml
+++ b/.hound.yml
@@ -3,4 +3,5 @@ ruby:
 haml:
   config_file: .haml-lint.yml
 eslint:
-  enabled: false
+  enabled: true
+  config_file: .eslintrc


### PR DESCRIPTION
## Background

Setup HoundCI to support newer JS features, such as those used in our new Vue frontend project.

Closes #694.

## Contents
- Configured HoundCI to use ESLint with the default linting config
