### PR TITLE
ci: Updates Dependabot to auto cache gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "build(deps): "
+    vendor: true
 
   - package-ecosystem: "npm"
     directory: "/website"


### PR DESCRIPTION
Updates Dependabot to automatically commit gem caches. Merging into develop to fast-track this fix.

Closes #713 