### PR TITLE
ci: Configure HoundCI to follow our SCSS style rules

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -5,3 +5,6 @@ haml:
 eslint:
   enabled: true
   config_file: .eslintrc
+sass-lint:
+  enabled: true
+  config_file: .sass-lint.yml

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,7 @@
+rules:
+  indentation:
+    - 2
+    -
+      size: 4
+  property-sort-order:
+    - 0

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,7 +1,6 @@
 rules:
   indentation:
     - 2
-    -
-      size: 4
+    - size: 4
   property-sort-order:
     - 0


### PR DESCRIPTION
## Content

- Set indentation level to 4 spaces instead of 2 spaces
- Disabled alphabetical ordering of CSS properties