### PR TITLE
ci: Configure HoundCI to allow mulitple SCSS selectors on one line

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -8,3 +8,5 @@ rules:
             - 'gap'
     property-sort-order:
         - 0
+    single-line-per-selector:
+        - 0


### PR DESCRIPTION
This fixes a linting issue spotted in #724 where HoundCI would reject the following SCSS syntax:

```scss
.foo, .bar {  // Selectors must be placed on new lines single-line-per-selector
    color: red;
}
```

This PR disables the `single-line-per-selector` linter warning.

Part of #694.