### PR TITLE
feat: Adds new ErrorResponse class

### DIFF
--- a/app/controllers/manage/application_controller.rb
+++ b/app/controllers/manage/application_controller.rb
@@ -1,3 +1,5 @@
+load 'lib/v3/error_response.rb'
+
 class Manage::ApplicationController < ApplicationController
   before_action :logged_in
   before_action :require_director_or_organizer_or_volunteer

--- a/app/controllers/manage/schools_controller.rb
+++ b/app/controllers/manage/schools_controller.rb
@@ -38,8 +38,7 @@ class Manage::SchoolsController < Manage::ApplicationController
   def perform_merge
     new_school_name = params[:school][:id]
     if new_school_name.blank?
-      # FIXME: This might need to be :unprocessable_entity
-      head :bad_request
+      render json: ErrorResponse.new(:login_merge_newSchoolNameMissing), status: :bad_request
       return
     end
 

--- a/lib/v3/error_response.rb
+++ b/lib/v3/error_response.rb
@@ -1,0 +1,10 @@
+class ErrorResponse
+  attr_accessor :error_identifier, :default_message
+
+  ERRORS = [:login_merge_newSchoolNameMissing].freeze
+
+  def initialize(error_identifier, default_message = nil)
+    @error_identifier = error_identifier
+    @default_message  = default_message
+  end
+end

--- a/test/controllers/manage/schools_controller_test.rb
+++ b/test/controllers/manage/schools_controller_test.rb
@@ -205,12 +205,21 @@ class Manage::SchoolsControllerTest < ActionController::TestCase
       assert_response :ok
     end
 
-    should "not merge into an invalid school" do
-      ["Nonexistent School", ""].each do |name|
+    should "not merge into a nonexistent school" do
+      ["Nonexistent School"].each do |name|
         assert_difference('School.count', 0) do
           patch :perform_merge, params: { id: @school, school: { id: name } }
         end
       end
+    end
+
+    should "not merge into a missing school" do
+      assert_difference('School.count', 0) do
+        patch :perform_merge, params: { id: @school, school: { id: "" } }
+      end
+      json = ActiveSupport::JSON.decode response.body
+      assert_equal json["error_identifier"], :login_merge_newSchoolNameMissing.to_s
+      assert_response :bad_request
     end
 
     should "merge schools" do


### PR DESCRIPTION
Adds a new ErrorResponse class for better communicating errors to our front-end. This class includes an error_identifier and default_message. To create, all you need to do is call `ErrorResponse.new` and supply an error symbol which are pulled from the `error_resposne.rb` class. HTTP status codes should continue to be sent as they normally were. 

The ErrorResponse creation line and HTTP status code can both be written as a one-liner for simplicity:
`render json: ErrorResponse.new(:login_merge_newSchoolNameMissing), status: :bad_request`

This pull request shows one usage example with the `school_controller.rb` controller, specifically the merge schools functionality which may fail for several different reasons.

Closes #798 