### PR TITLE
feat: Added FontAwesome icons via "vue-fontawesome"

### DIFF
--- a/frontend/components/base/Dropdown.vue
+++ b/frontend/components/base/Dropdown.vue
@@ -7,7 +7,7 @@
 
         <div class="dropdown" :class="{ 'opened': isOpen }" @click="toggleOpen" aria-hidden="true">
             <div class="name">
-                <p>{{ name }}</p>
+                <p>{{ name }} <font-awesome-icon :icon="isOpen ? 'chevron-up' : 'chevron-down'"></font-awesome-icon></p>
             </div>
 
             <div
@@ -25,8 +25,13 @@
 </template>
 
 <script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
+
 export default {
     name: 'Dropdown',
+    components: {
+        FontAwesomeIcon
+    },
     props: {
         name: String
     },

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,6 +2,9 @@ import { createApp } from "vue";
 import { createRouter, createWebHistory } from "vue-router"
 import { createI18n } from "vue-i18n"
 
+import { library } from "@fortawesome/fontawesome-svg-core"
+import { faChevronUp, faChevronDown } from "@fortawesome/free-solid-svg-icons"
+
 import App from "./App"
 
 import Home from "./routes/Home.vue"
@@ -50,6 +53,11 @@ if (!i18n.global.availableLocales.includes(desiredLocale)) {
     loadLocaleMessage(i18n, desiredLocale)
 }
 setI18nLangauge(i18n, desiredLocale)
+
+
+// needed for vue-fontawesome
+library.add(faChevronUp, faChevronDown)
+
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "hackengine",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/free-solid-svg-icons": "^5.15.4",
+        "@fortawesome/vue-fontawesome": "^3.0.0-5",
         "vue": "^3.1.1",
         "vue-i18n": "^9.1.7",
         "vue-router": "^4.0.8"
@@ -552,6 +555,48 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.0.0-5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.0-5.tgz",
+      "integrity": "sha512-aNmBT4bOecrFsZTog1l6AJDQHPP3ocXV+WQ3Ogy8WZCqstB/ahfhH4CPu5i4N9Hw0MBKXqE+LX+NbUxcj8cVTw==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@iarna/toml": {
@@ -11670,6 +11715,33 @@
           "dev": true
         }
       }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "3.0.0-5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.0-5.tgz",
+      "integrity": "sha512-aNmBT4bOecrFsZTog1l6AJDQHPP3ocXV+WQ3Ogy8WZCqstB/ahfhH4CPu5i4N9Hw0MBKXqE+LX+NbUxcj8cVTw==",
+      "requires": {}
     },
     "@iarna/toml": {
       "version": "2.2.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,9 @@
     "build": "parcel build ./index.html"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/vue-fontawesome": "^3.0.0-5",
     "vue": "^3.1.1",
     "vue-i18n": "^9.1.7",
     "vue-router": "^4.0.8"


### PR DESCRIPTION
Closes #731 

I will admit that vue-fontawesome is a bit boilerplate-y, since we have to call `library.add(...)` in `index.js` for every icon we want to use. However, the benefit of doing this in code instead of pulling FontAwesome from a CDN is that Parcel will [tree-shake](https://parceljs.org/features/production/#tree-shaking) unused SVG icons, greatly minimizing the impact FontAwesome has on our initial download size.