### PR TITLE
fix: Fixed Table rows sometimes showing in wrong order

### DIFF
--- a/frontend/components/base/Table.vue
+++ b/frontend/components/base/Table.vue
@@ -11,7 +11,7 @@
                 <tr>
                     <th v-if="showEditLink"></th>
 
-                    <th v-for="columnName in Object.values(shownColumns)" :key="columnName">
+                    <th v-for="columnName in shownColumns" :key="columnName">
                         {{ columnName }}
                     </th>
                 </tr>
@@ -98,7 +98,7 @@ export default {
             return Object.fromEntries(
                 Object.entries(row)
                     .filter(([key, value]) => shownColumnKeys.includes(key))
-                    .sort((x, y) => shownColumnKeys.indexOf(x[0]) < shownColumnKeys.indexOf(y[0]))
+                    .sort((x, y) => shownColumnKeys.indexOf(x[0]) > shownColumnKeys.indexOf(y[0]))
             )
         }
     }

--- a/frontend/components/base/Table.vue
+++ b/frontend/components/base/Table.vue
@@ -11,7 +11,7 @@
                 <tr>
                     <th v-if="showEditLink"></th>
 
-                    <th v-for="columnName in shownColumns" :key="columnName">
+                    <th v-for="columnName in Object.values(shownColumns)" :key="columnName">
                         {{ columnName }}
                     </th>
                 </tr>

--- a/frontend/components/base/Table.vue
+++ b/frontend/components/base/Table.vue
@@ -98,7 +98,7 @@ export default {
             return Object.fromEntries(
                 Object.entries(row)
                     .filter(([key, value]) => shownColumnKeys.includes(key))
-                    .sort((x, y) => shownColumnKeys.indexOf(x[0]) > shownColumnKeys.indexOf(y[0]))
+                    .sort((x, y) => shownColumnKeys.indexOf(x[0]) - shownColumnKeys.indexOf(y[0]))
             )
         }
     }

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -80,30 +80,36 @@
                     {
                         id: 1,
                         title: "lorem ipsum",
-                        description: "dolor sit amet"
+                        description: "dolor sit amet",
+                        features: "test test"
                     },
                     {
                         id: 2,
                         title: "lorem ipsum",
-                        description: "dolor sit amet"
+                        description: "dolor sit amet",
+                        features: "test test"
                     },
                     {
                         id: 3,
                         title: "lorem ipsum",
-                        description: "dolor sit amet"
+                        description: "dolor sit amet",
+                        features: "test test"
                     },
                     {
                         id: 4,
                         title: "lorem ipsum",
-                        description: "dolor sit amet"
+                        description: "dolor sit amet",
+                        features: "test test"
                     },
                     {
                         id: 5,
                         title: "lorem ipsum",
-                        description: "dolor sit amet"
+                        description: "dolor sit amet",
+                        features: "test test"
                     }
                 ],
                 tableColumns: {
+                    features: "Features",
                     description: "Description",
                     title: "Title"
                 }


### PR DESCRIPTION
Closes #879 

The Table in Home.vue was modified to reproduce the bug from the issue description:

![image](https://user-images.githubusercontent.com/16471311/145754259-a8cefdb1-d2aa-40a0-a883-ca33df6c7428.png)
![image](https://user-images.githubusercontent.com/16471311/145754280-cdcbc212-5ecf-4033-b6ce-6a5a38e2de6b.png)

I accidentally used an inequality instead of a subtraction for the comparator in `Table.filterRow()` (#872). After fixing:

![image](https://user-images.githubusercontent.com/16471311/145755370-48ccb425-0d00-47a0-844f-45cfcb0daa03.png)

I also forked `he-794` and tested the fix on the test case shown in the issue description, and it seems to fix it well:

![image](https://user-images.githubusercontent.com/16471311/145755596-84076885-79fc-47cc-9bdf-7845816c65ae.png)