### PR TITLE
fix: Show pointer cursor on Table edit links

### DIFF
--- a/frontend/components/base/Table.vue
+++ b/frontend/components/base/Table.vue
@@ -18,7 +18,7 @@
 
                 <tr v-for="(row, index) in rows" :key="index">
                     <td v-if="showEditLink">
-                        <font-awesome-icon icon="edit" @click="$emit('goToEdit', row)"></font-awesome-icon>
+                        <font-awesome-icon icon="edit" @click="$emit('goToEdit', row)" class="edit-icon"></font-awesome-icon>
                     </td>
 
                     <td v-for="(value, name) in filterRow(row)" :key="name">
@@ -148,6 +148,10 @@ tr:last-child {
         display: flex;
         width: 100%;
     }
+}
+
+.edit-icon {
+    cursor: pointer;
 }
 
 .pagination {

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -20,7 +20,7 @@
             <Radio content="Hello" name="radio-test" value="asdf"></Radio>
             <Radio content="Hello" name="radio-test" value="1234"></Radio>
 
-            <Table :rows="tableRows" :shownColumns="tableColumns"></Table>
+            <Table :rows="tableRows" :shownColumns="tableColumns" :showEditLink="true" @go-to-edit="tableEditRow"></Table>
 
             <VerticalGroup>
                 <a href="#">Item 1</a>
@@ -109,6 +109,11 @@
                 }
             }
         },
+        methods: {
+            tableEditRow(row) {
+                alert("clicked edit on row #" + row.id)
+            }
+        }
     };
 </script>
 


### PR DESCRIPTION
Closes #878

This PR also adds a simple "go to edit page" handler that shows an alert() to the test Table on the home page, just for testing purposes.

My apologies of using a phone picture instead of a screenshot, but I can't find a good way to get a screenshot with the pointer cursor specifically showing in Ubuntu:

![demo](https://user-images.githubusercontent.com/16471311/145756626-41efe07d-6764-469d-8716-4afe6f3a97d9.jpg)

