### PR TITLE
feat: Added `v-model` support to custom form components

### DIFF
--- a/frontend/components/base/Checkbox.vue
+++ b/frontend/components/base/Checkbox.vue
@@ -1,7 +1,11 @@
 <template>
 
     <label class="control-container">{{content}}
-        <input type="checkbox" :name="name" :value="value">
+        <input
+            type="checkbox"
+            :value="value"
+            @input="onChange($event.target)"
+        >
         <span class="control"></span>
     </label>
 </template>
@@ -9,13 +13,22 @@
 <script>
 export default {
     name: 'Checkbox',
+    methods: {
+        // inspired by https://stackoverflow.com/a/58201070
+        onChange(target) {
+            let currentValue = [...this.modelValue]
+            if (target.checked) {
+                currentValue.push(target.value)
+            } else {
+                currentValue = currentValue.filter(item => item !== target.value)
+            }
+            this.$emit('update:modelValue', currentValue);
+        }
+    },
     props: {
         content: String,
-        name: String,
+        modelValue: Boolean,
         value: String
-    },
-    data() {
-        return {}
     }
 }
 </script>

--- a/frontend/components/base/Checkbox.vue
+++ b/frontend/components/base/Checkbox.vue
@@ -4,7 +4,7 @@
         <input
             type="checkbox"
             :value="value"
-            @input="onChange($event.target)"
+            v-model="computedValue"
         >
         <span class="control"></span>
     </label>
@@ -13,21 +13,20 @@
 <script>
 export default {
     name: 'Checkbox',
-    methods: {
-        // inspired by https://stackoverflow.com/a/58201070
-        onChange(target) {
-            let currentValue = [...this.modelValue]
-            if (target.checked) {
-                currentValue.push(target.value)
-            } else {
-                currentValue = currentValue.filter(item => item !== target.value)
+    computed: {
+        computedValue: {
+            get() {
+                return this.modelValue
+            },
+            set(value) {
+                this.$emit('update:modelValue', value)
             }
-            this.$emit('update:modelValue', currentValue);
         }
     },
+    emits: ['update:modelValue'],
     props: {
         content: String,
-        modelValue: Boolean,
+        modelValue: Array,
         value: String
     }
 }

--- a/frontend/components/base/Dropdown.vue
+++ b/frontend/components/base/Dropdown.vue
@@ -1,7 +1,12 @@
 <template>
     <div class="input-dropdown">
         <!-- making this invisible so that screen readers can ignore the "pretty" version -->
-        <select class="invisible" :id="id" ref="select" :aria-label="withLabel ? null : label">
+        <select
+            class="invisible"
+            :id="id" ref="select"
+            :aria-label="withLabel ? null : label"
+            :value="modelValue"
+        >
             <slot></slot>
         </select>
 
@@ -37,6 +42,7 @@ export default {
     props: {
         id: String,
         label: String,
+        modelValue: String,
         withLabel: {
             type: Boolean,
             default: true
@@ -61,6 +67,7 @@ export default {
         select(option) {
             this.currentSelection = option;
             this.$refs.select.value = option.value;
+            this.$emit('update:modelValue', option.value)
         }
     }
 }

--- a/frontend/components/base/Radio.vue
+++ b/frontend/components/base/Radio.vue
@@ -1,6 +1,11 @@
 <template>
     <label class="control-container">{{ content }}
-        <input type="radio" :name="name" :value="value" checked>
+        <input
+            type="radio"
+            :name="name"
+            :value="value"
+            :checked="modelValue == value"
+            @input="$emit('update:modelValue', $event.target.value)">
         <span class="control"></span>
     </label>
 </template>
@@ -10,11 +15,9 @@ export default {
     name: 'Radio',
     props: {
         content: String,
+        modelValue: String,
         name: String,
         value: String
-    },
-    data() {
-        return {}
     }
 }
 </script>

--- a/frontend/components/base/Radio.vue
+++ b/frontend/components/base/Radio.vue
@@ -5,7 +5,8 @@
             :name="name"
             :value="value"
             :checked="modelValue == value"
-            @input="$emit('update:modelValue', $event.target.value)">
+            @input="$emit('update:modelValue', $event.target.value)"
+        >
         <span class="control"></span>
     </label>
 </template>

--- a/frontend/components/base/TextArea.vue
+++ b/frontend/components/base/TextArea.vue
@@ -1,7 +1,14 @@
 <template>
     <div>
         <label class="control-label" v-if="label" :for="id">{{ label }}</label>
-        <textarea class="input-textarea" :id="id" :cols="cols" :placeholder="placeholder"></textarea>
+        <textarea
+            class="input-textarea"
+            :id="id"
+            :cols="cols"
+            :placeholder="placeholder"
+            :value="modelValue"
+            @input="$emit('update:modelValue', $event.target.value)"
+        ></textarea>
     </div>
 </template>
 
@@ -11,6 +18,7 @@ export default {
     props: {
         id: String,
         label: String,
+        modelValue: String,
         placeholder: String,
         cols: {
             type: Number,

--- a/frontend/components/base/TextInput.vue
+++ b/frontend/components/base/TextInput.vue
@@ -1,7 +1,14 @@
 <template>
     <div>
         <label class="control-label" :for="id">{{ label }}</label>
-        <input type="text" :id="id" class="input-text" :placeholder="placeholder"/>
+        <input
+            type="text"
+            :id="id"
+            class="input-text"
+            :placeholder="placeholder"
+            :value="modelValue"
+            @input="$emit('update:modelValue', $event.target.value)"
+        />
     </div>
 </template>
 
@@ -11,6 +18,7 @@ export default {
     props: {
         id: String,
         label: String,
+        modelValue: String,
         placeholder: String
     },
     data() {

--- a/frontend/components/base/TextInput.vue
+++ b/frontend/components/base/TextInput.vue
@@ -8,7 +8,7 @@
             :placeholder="placeholder"
             :value="modelValue"
             @input="$emit('update:modelValue', $event.target.value)"
-        />
+        >
     </div>
 </template>
 

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -19,8 +19,8 @@
             <Checkbox content="Hello 2" value="test 2"></Checkbox>
             <Checkbox content="Hello 3" value="test 3"></Checkbox>
 
-            <Radio content="Hello" name="radio-test" value="asdf" v-model="testValue"></Radio>
-            <Radio content="Hello" name="radio-test" value="1234" v-model="testValue"></Radio>
+            <Radio content="Hello" name="radio-test" value="asdf"></Radio>
+            <Radio content="Hello" name="radio-test" value="1234"></Radio>
 
             <Table :rows="tableRows" :shownColumns="tableColumns"></Table>
 
@@ -36,7 +36,7 @@
                 <a href="#">Item 3</a>
             </HorizontalGroup>
 
-            <Dropdown label="Dropdown" :withLabel="false">
+            <Dropdown label="Dropdown" :withLabel="false" v-model="testValue">
                 <option selected>Item 1</option>
                 <option>Item 2</option>
                 <option>Item 3</option>
@@ -88,7 +88,7 @@
         },
         data() {
             return {
-                testValueInternal: "asdf",
+                testValueInternal: "Item 1",
                 name: "Home",
                 tableRows: [
                     {

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -11,16 +11,16 @@
             <Button content="Button"></Button>
             <Button content="Button"></Button>
 
-            <TextInput placeholder="Give password"></TextInput>
+            <TextInput placeholder="Give password" v-model="textInputVal"></TextInput>
 
-            <TextArea placeholder="Does the black moon howl?"></TextArea>
+            <TextArea placeholder="Does the black moon howl?" v-model="textAreaVal"></TextArea>
 
-            <Checkbox content="Hello 1" value="test 1"></Checkbox>
-            <Checkbox content="Hello 2" value="test 2"></Checkbox>
-            <Checkbox content="Hello 3" value="test 3"></Checkbox>
+            <Checkbox content="Hello 1" value="test 1" v-model="checkboxVal"></Checkbox>
+            <Checkbox content="Hello 2" value="test 2" v-model="checkboxVal"></Checkbox>
+            <Checkbox content="Hello 3" value="test 3" v-model="checkboxVal"></Checkbox>
 
-            <Radio content="Hello" name="radio-test" value="asdf"></Radio>
-            <Radio content="Hello" name="radio-test" value="1234"></Radio>
+            <Radio content="Hello" name="radio-test" value="asdf" v-model="radioVal"></Radio>
+            <Radio content="Hello" name="radio-test" value="1234" v-model="radioVal"></Radio>
 
             <Table :rows="tableRows" :shownColumns="tableColumns"></Table>
 
@@ -36,7 +36,7 @@
                 <a href="#">Item 3</a>
             </HorizontalGroup>
 
-            <Dropdown label="Dropdown" :withLabel="false" v-model="testValue">
+            <Dropdown label="Dropdown" :withLabel="false" v-model="dropdownVal">
                 <option selected>Item 1</option>
                 <option>Item 2</option>
                 <option>Item 3</option>
@@ -76,20 +76,70 @@
             TextArea
         },
         computed: {
-            testValue: {
+            // simplest way to verify model bindings for input components
+
+            textInputVal: {
                 get() {
-                    return this.testValueInternal
+                    return this._textInputVal
                 },
                 set(value) {
-                    this.testValueInternal = value
+                    this._textInputVal = value
+                    alert(value)
+                }
+            },
+
+            textAreaVal: {
+                get() {
+                    return this._textAreaVal
+                },
+                set(value) {
+                    this._textAreaVal = value
+                    alert(value)
+                }
+            },
+
+            checkboxVal: {
+                get() {
+                    return this._checkboxVal
+                },
+                set(value) {
+                    this._checkboxVal = value
+                    alert(value)
+                }
+            },
+
+            radioVal: {
+                get() {
+                    return this._radioVal
+                },
+                set(value) {
+                    this._radioVal = value
+                    alert(value)
+                }
+            },
+
+            dropdownVal: {
+                get() {
+                    return this._dropdownVal
+                },
+                set(value) {
+                    this._dropdownVal = value
                     alert(value)
                 }
             }
         },
         data() {
             return {
-                testValueInternal: "Item 1",
                 name: "Home",
+
+                // input component models
+                _textInputVal: "",
+                _textAreaVal: "",
+                _checkboxVal: [],
+                _radioVal: "",
+                _dropdownVal: "",
+
+                // table setup
                 tableRows: [
                     {
                         id: 1,

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -11,9 +11,9 @@
             <Button content="Button"></Button>
             <Button content="Button"></Button>
 
-            <TextInput placeholder="Give password" v-model="testValue"></TextInput>
+            <TextInput placeholder="Give password"></TextInput>
 
-            <TextArea placeholder="Does the black moon howl?"></TextArea>
+            <TextArea placeholder="Does the black moon howl?" v-model="testValue"></TextArea>
 
             <Checkbox content="Hello" name="checkbox-test" value="test"></Checkbox>
 

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -15,12 +15,12 @@
 
             <TextArea placeholder="Does the black moon howl?"></TextArea>
 
-            <Checkbox content="Hello 1" value="test 1" v-model="testValue"></Checkbox>
-            <Checkbox content="Hello 2" value="test 2" v-model="testValue"></Checkbox>
-            <Checkbox content="Hello 3" value="test 3" v-model="testValue"></Checkbox>
+            <Checkbox content="Hello 1" value="test 1"></Checkbox>
+            <Checkbox content="Hello 2" value="test 2"></Checkbox>
+            <Checkbox content="Hello 3" value="test 3"></Checkbox>
 
-            <Radio content="Hello" name="radio-test" value="asdf"></Radio>
-            <Radio content="Hello" name="radio-test" value="1234"></Radio>
+            <Radio content="Hello" name="radio-test" value="asdf" v-model="testValue"></Radio>
+            <Radio content="Hello" name="radio-test" value="1234" v-model="testValue"></Radio>
 
             <Table :rows="tableRows" :shownColumns="tableColumns"></Table>
 
@@ -88,7 +88,7 @@
         },
         data() {
             return {
-                testValueInternal: [],
+                testValueInternal: "asdf",
                 name: "Home",
                 tableRows: [
                     {

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -11,7 +11,7 @@
             <Button content="Button"></Button>
             <Button content="Button"></Button>
 
-            <TextInput placeholder="Give password"></TextInput>
+            <TextInput placeholder="Give password" v-model="testValue"></TextInput>
 
             <TextArea placeholder="Does the black moon howl?"></TextArea>
 
@@ -73,8 +73,20 @@
             Dropdown,
             TextArea
         },
+        computed: {
+            testValue: {
+                get() {
+                    return this.testValueInternal
+                },
+                set(value) {
+                    this.testValueInternal = value
+                    alert(value)
+                }
+            }
+        },
         data() {
             return {
+                testValueInternal: "test",
                 name: "Home",
                 tableRows: [
                     {

--- a/frontend/routes/Home.vue
+++ b/frontend/routes/Home.vue
@@ -13,9 +13,11 @@
 
             <TextInput placeholder="Give password"></TextInput>
 
-            <TextArea placeholder="Does the black moon howl?" v-model="testValue"></TextArea>
+            <TextArea placeholder="Does the black moon howl?"></TextArea>
 
-            <Checkbox content="Hello" name="checkbox-test" value="test"></Checkbox>
+            <Checkbox content="Hello 1" value="test 1" v-model="testValue"></Checkbox>
+            <Checkbox content="Hello 2" value="test 2" v-model="testValue"></Checkbox>
+            <Checkbox content="Hello 3" value="test 3" v-model="testValue"></Checkbox>
 
             <Radio content="Hello" name="radio-test" value="asdf"></Radio>
             <Radio content="Hello" name="radio-test" value="1234"></Radio>
@@ -86,7 +88,7 @@
         },
         data() {
             return {
-                testValueInternal: "test",
+                testValueInternal: [],
                 name: "Home",
                 tableRows: [
                     {


### PR DESCRIPTION
Closes #884; unblocks #874 and (partially) #794

---

All existing form elements with values (Checkbox, Dropdown, Radio, TextArea, TextInput) are now compatible with `v-model`, featuring behavior expected of the native form elements they wrap.

`he-884` is currently set up to have all relevant form elements in `Home.vue` show an alert when the bound model field is changed. This makes testing easier, but it might be annoying in the future; I can revert [the commit that adds this behavior](https://github.com/codeRIT/hackathon-manager/commit/9eee2a7cabf2a5753568c24d78cedc52f4b5a4c4) before merging if y'all want.