### PR TITLE
fix: Remove manual mysql dependency in CI for msyql `8.0.26`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,6 @@ jobs:
           sudo apt-get install -y build-essential
           sudo apt-get install -y libxslt-dev
           sudo apt-get install -y libxml2-dev
-          sudo apt-get install -y default-libmysqlclient-dev
-          sudo apt-get install -y default-mysql-client
     - name: Set up Ruby
       env:
         ImageOS: ubuntu18

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # HackathonManager
 
-Test
-
 [![Build Status](https://travis-ci.org/codeRIT/hackathon-manager.svg?branch=master)](https://travis-ci.org/codeRIT/hackathon-manager)
 [![Code Climate](https://codeclimate.com/github/codeRIT/hackathon-manager/badges/gpa.svg)](https://codeclimate.com/github/codeRIT/hackathon-manager)
 [![Test Coverage](https://codeclimate.com/github/codeRIT/hackathon-manager/badges/coverage.svg)](https://codeclimate.com/github/codeRIT/hackathon-manager/coverage)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HackathonManager
 
+Test
+
 [![Build Status](https://travis-ci.org/codeRIT/hackathon-manager.svg?branch=master)](https://travis-ci.org/codeRIT/hackathon-manager)
 [![Code Climate](https://codeclimate.com/github/codeRIT/hackathon-manager/badges/gpa.svg)](https://codeclimate.com/github/codeRIT/hackathon-manager)
 [![Test Coverage](https://codeclimate.com/github/codeRIT/hackathon-manager/badges/coverage.svg)](https://codeclimate.com/github/codeRIT/hackathon-manager/coverage)


### PR DESCRIPTION
Resolves #889 

GitHub Actions seems to have reverted to a previous mysql version (8.0.27 -> 8.0.26) such that manually installing these two dependencies is, at least for now, no longer necessary. 

This will probably need to be reverted or at least rechecked in the future when msyql is eventually upgraded again.

See issue for detailed discussion.